### PR TITLE
fix(deploy): unbreak vercel build (package.json available at build time)

### DIFF
--- a/simulation/frontend/.vercelignore
+++ b/simulation/frontend/.vercelignore
@@ -1,6 +1,2 @@
 node_modules/
-app.ts
-tsconfig.json
-package.json
-package-lock.json
 *.tsbuildinfo


### PR DESCRIPTION
## Summary
Previous `.vercelignore` stripped `package.json` and `tsconfig.json` during Vercel's clone step, so `npm run build` (tsc) had nothing to compile and failed with `ENOENT` on `package.json`. Now only excludes `node_modules/` and `*.tsbuildinfo`.

## Test plan
- [ ] Vercel rebuild succeeds — no more "No Output Directory" or ENOENT errors
- [ ] `curl https://millennium-data-quality-25-26.vercel.app/api/status` returns `{"ready": true, "tickers": 503, ...}` (proxied to Fly)
- [ ] Site status bar reads "ready · 503 tickers" and equity curve renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)