### PR TITLE
Trading-terminal UI redesign (Mantine-dark, IMC-Prosperity)

### DIFF
--- a/simulation/frontend/index.html
+++ b/simulation/frontend/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="light">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -9,23 +9,12 @@
   <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script>
-  <script>
-    // Apply persisted theme before paint to avoid flash.
-    (() => {
-      try {
-        const t = localStorage.getItem("sim-theme");
-        if (t === "light" || t === "dark") {
-          document.documentElement.setAttribute("data-theme", t);
-        }
-      } catch (_) { /* ignore */ }
-    })();
-  </script>
 </head>
 <body>
   <div id="progress" class="progress idle"></div>
 
   <header class="topbar">
-    <div class="brand">Strategy <em>Simulator</em></div>
+    <div class="brand">SIM<em>·</em>BACKTESTER</div>
     <nav class="strategy-tabs" id="strategy-tabs"></nav>
     <div class="horizon">
       <input id="start" type="date" value="2005-01-01" />
@@ -35,18 +24,10 @@
     <div class="source-picker" title="data source">
       <select id="source-select" aria-label="Data source">
         <option value="yfinance">yfinance · S&amp;P 500</option>
-        <option value="wharton">Wharton WRDS · ~865 tickers</option>
+        <option value="wharton">Wharton WRDS · ~865</option>
       </select>
     </div>
-    <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Toggle theme">
-      <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-        <circle cx="12" cy="12" r="4"/>
-        <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
-      </svg>
-      <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-        <path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z"/>
-      </svg>
-    </button>
+    <button id="theme-toggle" class="theme-toggle" type="button" aria-hidden="true" tabindex="-1"></button>
   </header>
 
   <main class="layout">
@@ -54,7 +35,7 @@
       <aside class="sidebar">
         <div class="panel controls-panel">
           <header class="panel-head">
-            <h3><span class="figno">§ I</span>Parameters</h3>
+            <h3>Parameters</h3>
             <span class="panel-sub" id="universe-label">universe: loading…</span>
           </header>
           <p class="strategy-summary" id="strategy-summary"></p>
@@ -70,10 +51,10 @@
           <div class="universe-box">
             <div class="universe-head">
               <label for="universe-input">Universe</label>
-              <span class="universe-status" id="universe-status">all cached (503)</span>
+              <span class="universe-status" id="universe-status">all cached</span>
             </div>
             <textarea id="universe-input"
-              placeholder="leave blank for full S&P 500, or paste e.g. AAPL, MSFT, NVDA, JPM"
+              placeholder="blank = full universe · or AAPL, MSFT, NVDA, JPM"
               rows="2"></textarea>
             <div class="universe-actions">
               <button id="universe-apply" type="button">Apply</button>
@@ -81,15 +62,14 @@
               <button id="universe-reset" type="button" title="clear override and use full cache">Reset</button>
             </div>
             <p class="universe-help">
-              Enter tickers comma- or newline-separated. Use <em>Apply</em> to restrict the run
-              to <em>just those</em> names; use <em>Exclude</em> to run on
-              <em>everything except</em> those names. Tickers not in the cache are ignored
-              (this button never mutates the cached universe).
+              <em>Apply</em> restricts the run to the names you list.
+              <em>Exclude</em> runs on everything else in the cache.
+              Tickers not in the cache are ignored.
             </p>
             <p id="universe-source-note" class="universe-source-note" hidden>
-              <em>Wharton</em> is a static panel — you can <em>filter</em> to a subset of the
+              <em>Wharton</em> is a static panel — filter to a subset of the
               ~865 tickers it ships with, but you can't fetch new ones. Switch to
-              <em>yfinance</em> in the top bar to add tickers live.
+              <em>yfinance</em> in the top bar to add live tickers.
             </p>
           </div>
         </div>
@@ -98,7 +78,7 @@
       <div class="main-col">
         <div class="panel code-panel">
           <header class="panel-head">
-            <h3><span class="figno">§ II</span>Live code</h3>
+            <h3>Live code</h3>
             <span class="panel-sub" id="code-path">strategies/research_strategies.py + backtester/research_backtester.py</span>
           </header>
           <pre class="code-block"><code id="code-live" class="language-python"></code></pre>
@@ -113,10 +93,10 @@
 
         <div class="panel">
           <header class="panel-head">
-            <h3><span class="figno">§ III</span>Equity curve</h3>
+            <h3>Equity curve</h3>
             <div class="panel-actions">
               <button id="pin-current" class="ghost-btn" type="button" title="pin the current run as a comparison curve on this chart">
-                <span class="pin-icon" aria-hidden="true">＋</span>Pin to overlay
+                <span class="pin-icon" aria-hidden="true">+</span>Pin
               </button>
             </div>
           </header>
@@ -128,18 +108,14 @@
             </header>
             <div id="pinned-list" class="pinned-list"></div>
             <p id="pinned-empty" class="pinned-empty">
-              Run a backtest, then <em>Pin to overlay</em> to compare it against the next run.
-              Tweak <em>lookback</em>, change strategies, or shift the date window — pinned curves stay on the chart.
+              Run a backtest then <em>Pin</em> to compare against the next run. Tweak params, change strategies, shift dates — pinned curves stay on the chart.
             </p>
           </section>
-          <p class="figure-cap"><span class="figno">Fig. 1</span>Cumulative return of the strategy net of transaction cost, plotted against the equal-weighted universe. Pinned comparison runs overlay in the editorial palette.</p>
         </div>
-
-        <div class="dingbat">❦</div>
 
         <div class="panel">
           <header class="panel-head">
-            <h3><span class="figno">§ IV</span>Survivorship audit</h3>
+            <h3>Survivorship audit</h3>
             <span class="panel-sub" id="audit-sub">point-in-time view of the universe this run saw</span>
           </header>
           <div class="audit-body">
@@ -147,14 +123,11 @@
             <div id="chart-audit" class="audit-chart"></div>
             <p class="audit-note" id="audit-note"></p>
           </div>
-          <p class="figure-cap"><span class="figno">Fig. 2</span>Active-ticker count over the backtest window — the surviving universe seen by this run.</p>
         </div>
-
-        <div class="dingbat">❦</div>
 
         <div class="panel">
           <header class="panel-head">
-            <h3><span class="figno">§ V</span>Data inspector</h3>
+            <h3>Data inspector</h3>
             <span class="panel-sub" id="data-sub"></span>
           </header>
           <div class="data-body">

--- a/simulation/frontend/style.css
+++ b/simulation/frontend/style.css
@@ -1,86 +1,88 @@
 /* ============================================================
-   Strategy Simulator — "Editorial Whitepaper" theme
-   A quant-research dashboard rendered as a serif essay.
-   Two faces: New York (serif) + Inter / system (sans).
-   Color reserved for meaning: q (cinnabar) = strategy,
-   k (prussian) = benchmark, accent (gold) = editorial marks.
+   Strategy Simulator — trading terminal
+   Mantine-dark base · 1px hairlines · monospace-dominant numerics
+   No decoration. The data is the design.
    ============================================================ */
 
-:root[data-theme="light"] {
-  --bg:          #f6f2e8;   /* warm cream paper */
-  --bg-tint:     #fbf7ee;   /* slightly lighter cream */
-  --card:        #ffffff;
-  --ink:         #11131a;   /* near-black, warm undertone */
-  --ink-soft:    #3c4250;   /* body text — never pure ink */
-  --muted:       #8a8f9b;
-  --rule:        #e3dfd2;   /* hairline rules tinted to bg */
-  --rule-soft:   #ece8db;
-  --q:           #c94a3a;   /* cinnabar — strategy */
-  --q-ghost:     #e7bdb6;
-  --k:           #26578f;   /* prussian — benchmark */
-  --k-ghost:     #b9c8dd;
-  --accent:      #b8864a;   /* warm gold — editorial marks */
-  --accent-tint: #f3e9d4;
-  /* Series colors for pinned overlay runs. Picked to read distinctly
-     against cream paper without screaming AI-bright primaries. */
-  --ser-a:       #4f7c47;   /* moss green */
-  --ser-b:       #7a3a5c;   /* aubergine */
-  --ser-c:       #c8893f;   /* ochre */
-  --ser-d:       #355d7a;   /* deep teal */
-  --ser-e:       #98452e;   /* terracotta */
-  --ser-f:       #5d5a4f;   /* slate */
-  --chrome:      rgba(17,19,26,0.06);
-  --good:        #2f7a4f;
-  --bad:         #b84236;
-  --warn:        #b8864a;
-  --shadow-ring: 0 1px 2px rgba(17,19,26,0.04), 0 0 0 1px rgba(17,19,26,0.05);
-}
-:root[data-theme="dark"] {
-  --bg:          #17161a;
-  --bg-tint:     #1d1c1f;
-  --card:        #1e1d21;
-  --ink:         #e8e2d0;
-  --ink-soft:    #b3ad99;
-  --muted:       #7a7668;
-  --rule:        #2e2b26;
-  --rule-soft:   #25231f;
-  --q:           #e87565;
-  --q-ghost:     #5a3730;
-  --k:           #6f96c8;
-  --k-ghost:     #2b3a52;
-  --accent:      #d8a96a;
-  --accent-tint: #2d2418;
-  --ser-a:       #7eb072;   /* moss */
-  --ser-b:       #c98aa8;   /* aubergine, lifted */
-  --ser-c:       #e8b07a;   /* ochre */
-  --ser-d:       #7ea6cd;   /* teal */
-  --ser-e:       #d68b78;   /* terracotta */
-  --ser-f:       #a39e8e;   /* slate */
-  --chrome:      rgba(232,226,208,0.08);
-  --good:        #6fb88f;
-  --bad:         #e87565;
-  --warn:        #d8a96a;
-  --shadow-ring: 0 1px 2px rgba(0,0,0,0.4), 0 0 0 1px rgba(232,226,208,0.06);
+:root {
+  --bg-app:        #0d0e10;
+  --bg-panel:      #131418;
+  --bg-panel-2:    #1a1b1f;
+  --bg-elevated:   #22232a;
+  --bg-tint:       #131418;          /* alias for chart bg */
+
+  --border:        #2a2c33;
+  --border-soft:   #1f2128;
+  --border-strong: #3a3d46;
+
+  --text:          #d4d6dc;
+  --text-1:        #d4d6dc;
+  --text-2:        #9ea1aa;
+  --text-3:        #6c6f78;
+  --text-mute:     #4d5058;
+
+  --accent:        #e8b62c;          /* gold — selected/active state ONLY */
+  --accent-soft:   rgba(232,182,44,0.10);
+  --link:          #4ea1f4;           /* clickable / focus */
+  --link-hover:    #6db4ff;
+
+  --pos:           #2faa5e;
+  --pos-soft:      rgba(47,170,94,0.12);
+  --neg:           #d24545;
+  --neg-soft:      rgba(210,69,69,0.12);
+  --warn:          #e8b62c;
+
+  /* Chart-internal aliases used by app.ts chartPalette() */
+  --ink:           var(--text-1);
+  --ink-soft:      var(--text-2);
+  --muted:         var(--text-3);
+  --rule:          var(--border);
+  --rule-soft:     var(--border-soft);
+  --q:             #4ea1f4;          /* live strategy curve — blue */
+  --q-ghost:       rgba(78,161,244,0.18);
+  --k:             #6c6f78;          /* benchmark — neutral grey, dotted */
+  --k-ghost:       rgba(108,111,120,0.18);
+  --accent-tint:   rgba(232,182,44,0.18);
+
+  /* Series rotation for pinned overlay runs (avoid red/green to keep
+     P&L semantics clean; bias toward distinguishable hues) */
+  --ser-a:         #e8b62c;          /* gold */
+  --ser-b:         #be7bdb;          /* violet */
+  --ser-c:         #15aabf;          /* cyan */
+  --ser-d:         #fd9e3a;          /* orange */
+  --ser-e:         #4ea1f4;          /* blue (matches q for live) */
+  --ser-f:         #b6c0c8;          /* light grey */
+
+  --radius: 3px;
+
+  --font-sans: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI",
+               Roboto, Helvetica, Arial, sans-serif;
+  --font-mono: "JetBrains Mono", "IBM Plex Mono", "SF Mono", ui-monospace,
+               Menlo, Consolas, monospace;
 }
 
 * { box-sizing: border-box; }
 html, body { height: 100%; }
-html { font-size: 16.5px; }
+html { font-size: 14px; }
 body {
   margin: 0;
-  background: var(--bg);
-  color: var(--ink-soft);
-  font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-  font-size: 0.95rem;
-  line-height: 1.6;
+  background: var(--bg-app);
+  color: var(--text-1);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  line-height: 1.45;
   -webkit-font-smoothing: antialiased;
-  font-feature-settings: 'ss01','cv11','calt','kern';
-  transition: background 0.3s ease, color 0.3s ease;
+  font-variant-ligatures: none;
   overflow-x: hidden;
 }
 img, canvas, svg, video { max-width: 100%; }
+em, .it { font-style: italic; color: var(--text-1); }
+a, a:visited { color: var(--link); text-decoration: none; }
+a:hover { color: var(--link-hover); text-decoration: underline; }
 
-em, .it { font-style: italic; color: var(--ink); }
+*::-webkit-scrollbar { width: 8px; height: 8px; }
+*::-webkit-scrollbar-thumb { background: var(--bg-elevated); border-radius: 0; }
+*::-webkit-scrollbar-track { background: transparent; }
 
 /* ---- Top progress bar ---- */
 .progress {
@@ -89,958 +91,857 @@ em, .it { font-style: italic; color: var(--ink); }
 }
 .progress::after {
   content: ""; display: block; height: 100%;
-  background: var(--q); width: var(--p, 0%);
-  transition: width 0.25s ease, background 0.2s ease;
+  background: var(--link); width: var(--p, 0%);
+  transition: width 0.18s linear;
 }
-.progress.idle::after { background: var(--accent); }
+.progress.idle::after { background: var(--accent); opacity: 0.5; }
 
 /* ---- Topbar ---- */
 .topbar {
   display: grid;
-  grid-template-columns: auto 1fr auto auto auto;
-  align-items: baseline;
-  gap: 1.5rem;
-  padding: 1.5rem 2rem 1rem;
-  border-bottom: 1px solid var(--rule);
-  background: var(--bg);
+  grid-template-columns: auto 1fr auto auto;
+  align-items: center;
+  gap: 14px;
+  padding: 7px 14px;
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--border);
   position: sticky; top: 0; z-index: 5;
+  height: 40px;
 }
 .brand {
-  font-family: 'New York', ui-serif, 'Iowan Old Style', Georgia, serif;
+  font-family: var(--font-mono);
+  font-size: 11px;
   font-weight: 600;
-  font-size: 1.32rem;
-  letter-spacing: -0.012em;
-  color: var(--ink);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-1);
 }
 .brand em {
-  font-style: italic; font-weight: 500;
-  background: linear-gradient(180deg, transparent 66%, var(--accent-tint) 66%);
-  padding: 0 0.08em;
+  font-style: normal;
+  color: var(--accent);
+  margin-left: 0.4em;
 }
+
 .strategy-tabs {
-  display: flex; gap: 1.6rem; flex-wrap: wrap;
-  align-items: baseline;
+  display: flex;
+  align-items: center;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-app);
+  height: 26px;
+  overflow: hidden;
   justify-self: center;
 }
 .strategy-tabs button {
   background: transparent;
   border: 0;
-  padding: 0.1rem 0;
-  font-family: 'New York', ui-serif, Georgia, serif;
-  font-style: italic;
-  font-size: 1.02rem;
-  color: var(--muted);
+  border-right: 1px solid var(--border);
+  padding: 0 12px;
+  height: 100%;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--text-2);
   cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
-  border-bottom: 1px solid transparent;
+  transition: color 0.1s, background 0.1s;
 }
-.strategy-tabs button:hover { color: var(--ink); }
+.strategy-tabs button:last-child { border-right: 0; }
+.strategy-tabs button:hover { color: var(--text-1); background: var(--bg-panel-2); }
 .strategy-tabs button.active {
-  color: var(--ink);
-  border-bottom-color: var(--accent);
+  color: var(--bg-app);
+  background: var(--accent);
+  font-weight: 600;
 }
 
-.horizon { display: flex; align-items: baseline; gap: 0.45rem; }
-.horizon span {
-  font-family: 'New York', ui-serif, Georgia, serif;
-  font-style: italic; color: var(--muted);
-}
+.horizon { display: flex; align-items: center; gap: 6px; }
+.horizon span { font-family: var(--font-mono); color: var(--text-3); font-size: 11px; }
 .horizon input[type="date"] {
-  background: transparent;
-  border: 0;
-  border-bottom: 1px solid var(--rule);
-  color: var(--ink);
-  padding: 0.18rem 0.1rem;
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 0.82rem;
+  background: var(--bg-app);
+  border: 1px solid var(--border);
+  color: var(--text-1);
+  padding: 3px 6px;
+  border-radius: var(--radius);
+  font-family: var(--font-mono);
+  font-size: 11px;
   font-variant-numeric: tabular-nums;
-  color-scheme: light;
+  height: 24px;
+  color-scheme: dark;
 }
-:root[data-theme="dark"] .horizon input[type="date"] { color-scheme: dark; }
-.horizon input[type="date"]:focus {
-  outline: none; border-bottom-color: var(--accent);
-}
+.horizon input[type="date"]:focus { outline: none; border-color: var(--link); }
 
-/* ---- Data source picker ---- */
-.source-picker {
-  position: relative;
-  display: inline-flex; align-items: baseline;
-}
+.source-picker { position: relative; display: inline-flex; }
 .source-picker::after {
-  content: "▾";
-  position: absolute; right: 0.55rem; top: 0.32rem;
-  font-size: 0.65rem;
-  color: var(--muted);
-  pointer-events: none;
+  content: "▾"; position: absolute; right: 6px; top: 4px;
+  font-size: 10px; color: var(--text-3); pointer-events: none;
 }
 .source-picker select {
-  appearance: none;
-  -webkit-appearance: none;
-  background: transparent;
-  border: 1px solid var(--rule);
-  color: var(--ink);
-  padding: 0.32rem 1.4rem 0.32rem 0.7rem;
-  border-radius: 999px;
-  font-family: 'New York', ui-serif, Georgia, serif;
-  font-style: italic;
-  font-size: 0.86rem;
+  appearance: none; -webkit-appearance: none;
+  background: var(--bg-app);
+  border: 1px solid var(--border);
+  color: var(--text-1);
+  padding: 0 22px 0 10px;
+  height: 26px;
+  border-radius: var(--radius);
+  font-family: var(--font-mono);
+  font-size: 11px;
   cursor: pointer;
-  transition: border-color 0.15s, color 0.15s;
 }
-.source-picker select:hover { border-color: var(--accent); }
-.source-picker select:focus {
-  outline: none; border-color: var(--accent);
-  box-shadow: 0 0 0 2px var(--accent-tint);
-}
+.source-picker select:hover { border-color: var(--border-strong); }
+.source-picker select:focus { outline: none; border-color: var(--link); }
 
-.universe-source-note {
-  margin: 0;
-  padding: 0.45rem 0.6rem;
-  background: var(--accent-tint);
-  border-left: 2px solid var(--accent);
-  border-radius: 0 3px 3px 0;
-  font-family: 'New York', ui-serif, Georgia, serif;
-  font-style: italic;
-  font-size: 0.84rem;
-  line-height: 1.5;
-  color: var(--ink-soft);
-}
-.universe-source-note em { color: var(--ink); font-weight: 500; }
-
-/* ---- Theme toggle ---- */
-.theme-toggle {
-  width: 38px; height: 38px;
-  border-radius: 50%;
-  background: var(--bg-tint);
-  border: 0;
-  display: inline-flex; align-items: center; justify-content: center;
-  cursor: pointer;
-  color: var(--ink-soft);
-  box-shadow: var(--shadow-ring);
-  transition: transform 0.15s ease, color 0.15s ease;
-}
-.theme-toggle:hover { transform: translateY(-1px); color: var(--ink); }
-.theme-toggle svg { width: 16px; height: 16px; display: block; }
-.theme-toggle .icon-moon { display: none; }
-:root[data-theme="dark"] .theme-toggle .icon-sun  { display: none; }
-:root[data-theme="dark"] .theme-toggle .icon-moon { display: block; }
+/* Theme toggle hidden — terminal is dark only */
+.theme-toggle { display: none; }
 
 /* ---- Layout ---- */
 .layout {
-  max-width: 1320px;
+  max-width: 1480px;
   margin: 0 auto;
-  padding: 2.4rem 2rem 5rem;
+  padding: 10px 12px 36px;
 }
 .app-split {
   display: grid;
-  grid-template-columns: 320px 1fr;
-  gap: 3rem;
+  grid-template-columns: 280px 1fr;
+  gap: 10px;
   align-items: start;
 }
 .sidebar {
   position: sticky;
-  top: 5rem;
-  max-height: calc(100vh - 6rem);
+  top: 50px;
+  max-height: calc(100vh - 60px);
   overflow-y: auto;
   align-self: start;
-  padding-right: 0.4rem;
 }
-.sidebar::-webkit-scrollbar { width: 6px; }
-.sidebar::-webkit-scrollbar-thumb { background: var(--rule); border-radius: 3px; }
 .main-col {
   display: flex; flex-direction: column;
+  gap: 10px;
   min-width: 0;
 }
 
-/* ---- Section / panel ---- */
+/* ---- Panel ---- */
 .panel {
-  background: transparent;
-  margin-bottom: 3.4rem;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   display: flex; flex-direction: column;
-  position: relative;
+  margin: 0;
 }
 .panel-head {
-  display: flex; align-items: baseline; justify-content: space-between;
-  gap: 1rem;
-  padding-bottom: 0.5rem;
-  margin-bottom: 1.2rem;
-  border-bottom: 1px solid var(--rule);
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 10px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border);
+  height: 30px;
+  background: var(--bg-panel-2);
 }
 .panel-head h3 {
   margin: 0;
-  font-family: 'New York', ui-serif, 'Iowan Old Style', Georgia, serif;
-  font-size: 1.45rem;
-  font-weight: 600;
-  letter-spacing: -0.012em;
-  color: var(--ink);
-}
-.panel-head .figno {
-  display: inline-block;
-  font-family: -apple-system, 'Inter', sans-serif;
-  font-size: 0.66rem;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
   font-weight: 600;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--accent);
-  margin-right: 0.55rem;
-  vertical-align: 0.2em;
+  color: var(--text-1);
 }
+.panel-head .figno { display: none; }
 .panel-sub {
-  font-family: 'New York', ui-serif, Georgia, serif;
-  font-style: italic;
-  font-size: 0.94rem;
-  color: var(--muted);
-  text-align: right;
-  flex-shrink: 0;
-}
-
-/* ---- Sidebar / controls ---- */
-.controls-panel { margin-bottom: 0; }
-.controls-panel .panel-head { margin-bottom: 0.9rem; }
-.controls-panel .panel-head .panel-sub {
-  max-width: 60%;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-3);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
 }
+
+.controls-panel { padding: 0; }
+.controls-panel > .panel-head { border-radius: var(--radius) var(--radius) 0 0; }
+.controls-panel > *:not(.panel-head) { padding-left: 12px; padding-right: 12px; }
+.controls-panel > *:last-child { padding-bottom: 12px; }
+.controls-panel .strategy-summary { margin-top: 10px; margin-left: 12px; margin-right: 12px; padding-left: 8px; padding-right: 8px;}
+
 .strategy-summary {
-  font-family: 'New York', ui-serif, Georgia, serif;
-  font-style: italic;
-  font-size: 1.06rem;
-  line-height: 1.5;
-  color: var(--ink-soft);
-  margin: 0 0 0.85rem;
-  padding: 0.05rem 0 0.05rem 0.9rem;
+  margin: 0 0 8px;
+  padding: 6px 8px;
+  background: var(--bg-panel-2);
   border-left: 2px solid var(--accent);
+  font-family: var(--font-sans);
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: var(--text-2);
 }
-.strategy-summary::before {
-  content: "In brief";
-  display: block;
-  font-family: -apple-system, 'Inter', sans-serif;
-  font-style: normal;
-  font-size: 0.62rem;
-  font-weight: 600;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--accent);
-  margin-bottom: 0.25rem;
-}
+.strategy-summary::before { display: none; }
 .strategy-summary:empty,
 .strategy-sizing:empty,
 .audit-note:empty { display: none; }
-.strategy-sizing {
-  margin: 0 0 1.4rem;
-  padding-left: 0.9rem;
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 0.78rem;
-  color: var(--muted);
-  line-height: 1.55;
-  font-variant-numeric: tabular-nums;
-}
-.strategy-sizing .sizing-tag   { color: var(--k); }
-.strategy-sizing .sizing-short { color: var(--q); }
 
-.params {
-  display: flex; flex-direction: column;
-  gap: 1.05rem;
-  padding: 0;
+.strategy-sizing {
+  margin: 0 0 10px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-3);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.55;
 }
+.strategy-sizing .sizing-tag   { color: var(--pos); font-weight: 600; }
+.strategy-sizing .sizing-short { color: var(--neg); font-weight: 600; }
+
+/* Params */
+.params { display: flex; flex-direction: column; gap: 8px; }
 .params-divider {
   border: 0;
-  border-top: 1px solid var(--rule);
-  margin: 1.2rem 0;
+  border-top: 1px solid var(--border);
+  margin: 8px 0;
 }
-.param-row { display: flex; flex-direction: column; gap: 0.3rem; }
-.param-row .param-head {
-  display: flex; justify-content: space-between; align-items: baseline;
-  gap: 0.6rem;
+.param-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-rows: auto auto;
+  gap: 2px 8px;
+  align-items: center;
 }
+.param-row .param-head { display: contents; }
 .param-row label {
-  font-family: 'New York', ui-serif, Georgia, serif;
-  font-style: italic;
-  font-size: 0.98rem;
-  color: var(--ink);
+  grid-column: 1;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-2);
 }
 .param-row .param-value {
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 0.82rem;
+  grid-column: 2;
+  display: flex; align-items: center; gap: 4px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
   font-variant-numeric: tabular-nums;
-  color: var(--ink);
-  display: flex; align-items: baseline; gap: 0.25rem;
+  color: var(--text-1);
 }
 .param-row .param-value input[type="number"] {
-  width: 64px;
-  background: var(--bg-tint);
-  border: 1px solid var(--rule);
-  color: var(--ink);
-  padding: 2px 6px;
-  border-radius: 3px;
+  width: 56px;
+  background: var(--bg-app);
+  border: 1px solid var(--border);
+  color: var(--text-1);
+  padding: 1px 5px;
+  border-radius: var(--radius);
   font: inherit;
-  font-size: 0.82rem;
+  font-size: 11.5px;
   text-align: right;
   font-variant-numeric: tabular-nums;
   -moz-appearance: textfield;
+  height: 22px;
 }
 .param-row .param-value input[type="number"]::-webkit-outer-spin-button,
 .param-row .param-value input[type="number"]::-webkit-inner-spin-button {
   -webkit-appearance: none; margin: 0;
 }
-.param-row .param-value input[type="number"]:focus {
-  outline: none; border-color: var(--accent);
-  box-shadow: 0 0 0 2px var(--accent-tint);
-}
-.param-row .param-value .param-unit {
-  color: var(--muted); font-size: 0.78rem;
-}
-/* Per-row reset-to-default. Always present so layout doesn't jitter,
-   but visually quiet until the value diverges from default. */
+.param-row .param-value input[type="number"]:focus { outline: none; border-color: var(--link); }
+.param-row .param-value .param-unit { color: var(--text-3); font-size: 10px; }
 .param-row .param-value .param-reset {
   background: transparent;
   border: 0;
-  padding: 0;
-  margin-left: 0.15rem;
-  color: var(--rule);
-  font-size: 0.92rem;
+  padding: 0 2px;
+  margin-left: 1px;
+  color: var(--text-mute);
+  font-size: 11px;
   line-height: 1;
   cursor: pointer;
-  transition: color 0.15s ease, transform 0.15s ease;
+  transition: color 0.1s;
   user-select: none;
 }
-.param-row .param-value .param-reset:hover { color: var(--ink-soft); }
-.param-row .param-value .param-reset.active {
-  color: var(--accent);
-  cursor: pointer;
-}
-.param-row .param-value .param-reset.active:hover {
-  color: var(--ink); transform: rotate(-30deg);
-}
+.param-row .param-value .param-reset:hover { color: var(--text-1); }
+.param-row .param-value .param-reset.active { color: var(--accent); }
+.param-row .param-value .param-reset.active:hover { color: var(--text-1); }
 .param-row .param-value .param-reset:focus { outline: none; }
-.param-row .param-value .param-reset:focus-visible {
-  outline: 1px solid var(--accent);
-  outline-offset: 2px;
-  border-radius: 50%;
-}
+.param-row .param-value .param-reset:focus-visible { outline: 1px solid var(--link); outline-offset: 1px; }
 
-/* range sliders — hairline track + ink thumb */
 .param-row input[type="range"] {
   -webkit-appearance: none;
   appearance: none;
+  grid-column: 1 / -1;
   width: 100%;
   background: transparent;
-  margin: 6px 0 0;
-  height: 14px;
+  margin: 0;
+  height: 12px;
 }
-.param-row input[type="range"]::-webkit-slider-runnable-track {
-  height: 2px; background: var(--rule); border-radius: 1px;
-}
-.param-row input[type="range"]::-moz-range-track {
-  height: 2px; background: var(--rule); border-radius: 1px;
-}
+.param-row input[type="range"]::-webkit-slider-runnable-track { height: 1px; background: var(--border-strong); }
+.param-row input[type="range"]::-moz-range-track             { height: 1px; background: var(--border-strong); }
 .param-row input[type="range"]::-webkit-slider-thumb {
   -webkit-appearance: none;
-  width: 14px; height: 14px;
-  border-radius: 50%;
-  background: var(--ink);
-  border: 2px solid var(--bg);
-  box-shadow: 0 0 0 1px var(--ink);
-  margin-top: -6px;
+  width: 10px; height: 10px;
+  border-radius: 0;
+  background: var(--text-1);
+  border: 0;
+  margin-top: -5px;
   cursor: pointer;
-  transition: box-shadow 0.15s ease;
 }
 .param-row input[type="range"]::-moz-range-thumb {
-  width: 14px; height: 14px;
-  border-radius: 50%;
-  background: var(--ink);
-  border: 2px solid var(--bg);
-  box-shadow: 0 0 0 1px var(--ink);
+  width: 10px; height: 10px;
+  border-radius: 0;
+  background: var(--text-1);
+  border: 0;
   cursor: pointer;
 }
 .param-row input[type="range"]:focus { outline: none; }
-.param-row input[type="range"]:focus::-webkit-slider-thumb {
-  box-shadow: 0 0 0 1px var(--ink), 0 0 0 5px var(--accent-tint);
-}
-.param-row input[type="range"]:focus::-moz-range-thumb {
-  box-shadow: 0 0 0 1px var(--ink), 0 0 0 5px var(--accent-tint);
-}
+.param-row input[type="range"]:focus::-webkit-slider-thumb { background: var(--accent); }
+.param-row input[type="range"]:focus::-moz-range-thumb     { background: var(--accent); }
 
 .param-help {
-  font-family: 'New York', ui-serif, Georgia, serif;
-  font-style: italic;
-  font-size: 0.86rem;
-  line-height: 1.5;
-  color: var(--muted);
-  margin: 0.05rem 0 0;
+  grid-column: 1 / -1;
+  font-family: var(--font-sans);
+  font-size: 10.5px;
+  line-height: 1.4;
+  color: var(--text-3);
+  margin: 1px 0 0;
 }
 
-/* ---- Universe box ---- */
+/* Universe box */
 .universe-box {
-  display: flex; flex-direction: column; gap: 0.6rem;
-  margin-top: 0.2rem;
+  display: flex; flex-direction: column; gap: 6px;
+  margin-top: 4px;
 }
 .universe-head {
-  display: flex; align-items: baseline; justify-content: space-between;
-  gap: 0.6rem;
+  display: flex; align-items: center; justify-content: space-between;
 }
 .universe-head label {
-  font-family: 'New York', ui-serif, Georgia, serif;
-  font-style: italic;
-  font-size: 0.98rem;
-  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-2);
 }
 .universe-status {
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 0.74rem;
-  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-3);
   font-variant-numeric: tabular-nums;
 }
 .universe-box textarea {
   width: 100%;
-  min-height: 56px;
+  min-height: 44px;
   resize: vertical;
-  background: var(--bg-tint);
-  border: 1px solid var(--rule);
-  color: var(--ink);
-  padding: 8px 10px;
-  border-radius: 3px;
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 0.8rem;
+  background: var(--bg-app);
+  border: 1px solid var(--border);
+  color: var(--text-1);
+  padding: 6px 8px;
+  border-radius: var(--radius);
+  font-family: var(--font-mono);
+  font-size: 11px;
   line-height: 1.45;
 }
-.universe-box textarea:focus {
-  outline: none; border-color: var(--accent);
-  box-shadow: 0 0 0 2px var(--accent-tint);
-}
-.universe-actions { display: flex; gap: 0.45rem; }
+.universe-box textarea:focus { outline: none; border-color: var(--link); }
+.universe-actions { display: flex; gap: 4px; }
 .universe-actions button {
   flex: 1 1 auto;
-  background: transparent;
-  border: 1px solid var(--ink);
-  color: var(--ink);
-  padding: 0.4rem 0.6rem;
-  border-radius: 3px;
-  font-family: -apple-system, 'Inter', sans-serif;
-  font-size: 0.66rem;
-  letter-spacing: 0.14em;
+  background: var(--bg-app);
+  border: 1px solid var(--border);
+  color: var(--text-1);
+  padding: 4px 6px;
+  border-radius: var(--radius);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  font-weight: 600;
   cursor: pointer;
-  transition: background 0.15s, color 0.15s, transform 0.15s;
+  height: 24px;
+  transition: border-color 0.1s, background 0.1s;
 }
-.universe-actions button:hover {
-  background: var(--ink); color: var(--bg); transform: translateY(-1px);
-}
-.universe-actions button:disabled {
-  opacity: 0.4; cursor: progress;
-  transform: none; background: transparent; color: var(--ink);
-}
+.universe-actions button:hover { background: var(--bg-panel-2); border-color: var(--border-strong); }
+.universe-actions button:disabled { opacity: 0.4; cursor: not-allowed; }
 .universe-help {
   margin: 0;
-  font-family: 'New York', ui-serif, Georgia, serif;
-  font-style: italic;
-  font-size: 0.85rem;
-  line-height: 1.55;
-  color: var(--muted);
+  font-family: var(--font-sans);
+  font-size: 10.5px;
+  line-height: 1.45;
+  color: var(--text-3);
 }
-.universe-help em { color: var(--ink); font-weight: 500; font-style: italic; }
+.universe-help em { color: var(--text-1); font-style: normal; font-weight: 500; }
+
+.universe-source-note {
+  margin: 0;
+  padding: 5px 8px;
+  background: var(--accent-soft);
+  border-left: 2px solid var(--accent);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  font-family: var(--font-sans);
+  font-size: 10.5px;
+  line-height: 1.45;
+  color: var(--text-2);
+}
+.universe-source-note em { color: var(--accent); font-style: normal; font-weight: 500; }
 
 /* ---- Code panel ---- */
-.code-panel { /* uses default panel styling */ }
+.code-panel { padding: 0; }
 .code-block {
   margin: 0;
-  flex: 1 1 auto;
-  overflow: auto;
-  font-size: 0.82rem;
-  padding: 1.1rem 1.3rem !important;
-  background: var(--bg-tint) !important;
-  border: 1px solid var(--rule) !important;
-  border-radius: 3px !important;
-  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace !important;
-  line-height: 1.6;
-  tab-size: 4;
-  color: var(--ink-soft) !important;
+  border: 0 !important;
+  border-radius: 0 0 var(--radius) var(--radius) !important;
+  background: var(--bg-app) !important;
+  font-family: var(--font-mono) !important;
+  font-size: 11px !important;
+  line-height: 1.55;
+  padding: 10px 12px !important;
+  color: var(--text-1) !important;
   text-shadow: none !important;
-  max-height: 380px;
+  tab-size: 4;
+  max-height: 280px;
+  overflow: auto;
 }
 .code-block code {
   background: transparent !important;
   font-family: inherit !important;
   text-shadow: none !important;
   color: inherit !important;
+  font-size: inherit !important;
 }
-/* Override Prism Tomorrow tokens to match the warm palette */
 .code-block .token.comment,
 .code-block .token.prolog,
 .code-block .token.doctype,
-.code-block .token.cdata { color: var(--muted); font-style: italic; }
-.code-block .token.punctuation { color: var(--ink-soft); }
+.code-block .token.cdata { color: var(--text-3); font-style: italic; }
+.code-block .token.punctuation { color: var(--text-2); }
 .code-block .token.property,
 .code-block .token.tag,
 .code-block .token.boolean,
 .code-block .token.number,
 .code-block .token.constant,
 .code-block .token.symbol,
-.code-block .token.deleted { color: var(--q); }
+.code-block .token.deleted { color: #e8b62c; }
 .code-block .token.selector,
 .code-block .token.attr-name,
 .code-block .token.string,
 .code-block .token.char,
 .code-block .token.builtin,
-.code-block .token.inserted { color: var(--k); }
+.code-block .token.inserted { color: #2faa5e; }
 .code-block .token.atrule,
 .code-block .token.attr-value,
-.code-block .token.keyword { color: var(--accent); font-style: italic; }
+.code-block .token.keyword { color: #be7bdb; }
 .code-block .token.function,
-.code-block .token.class-name { color: var(--ink); font-weight: 500; }
+.code-block .token.class-name { color: #4ea1f4; }
 .code-block .token.regex,
 .code-block .token.important,
-.code-block .token.variable { color: var(--accent); }
-.code-block .token.operator { color: var(--ink-soft); background: transparent; }
+.code-block .token.variable { color: #fd9e3a; }
+.code-block .token.operator { color: var(--text-2); background: transparent; }
 
 /* ---- Metrics strip ---- */
 .metrics-strip {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 0;
-  border-top: 1px solid var(--rule);
-  border-bottom: 1px solid var(--rule);
-  margin-bottom: 2.6rem;
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
 }
 .m-card {
-  padding: 1rem 1.2rem;
-  border-right: 1px solid var(--rule);
+  padding: 8px 12px;
+  border-right: 1px solid var(--border);
 }
 .m-card:last-child { border-right: 0; }
 .m-label {
-  font-family: -apple-system, 'Inter', sans-serif;
-  font-size: 0.64rem;
-  font-weight: 600;
-  letter-spacing: 0.16em;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--muted);
-  margin-bottom: 0.4rem;
+  color: var(--text-3);
+  margin-bottom: 2px;
 }
 .m-value {
-  font-family: 'New York', ui-serif, Georgia, serif;
-  font-size: 1.95rem;
-  font-weight: 600;
+  font-family: var(--font-mono);
+  font-size: 18px;
+  font-weight: 500;
   font-variant-numeric: tabular-nums;
-  letter-spacing: -0.022em;
-  color: var(--ink);
-  line-height: 1.05;
+  color: var(--text-1);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
 }
-.m-value.good { color: var(--k); }
-.m-value.bad  { color: var(--q); }
+.m-value.good { color: var(--pos); }
+.m-value.bad  { color: var(--neg); }
 .m-sub {
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 0.74rem;
-  color: var(--muted);
-  margin-top: 0.4rem;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-3);
+  margin-top: 2px;
   font-variant-numeric: tabular-nums;
 }
 
-/* ---- Panel actions / inline controls ---- */
-.panel-actions { display: flex; align-items: center; gap: 0.6rem; }
+/* ---- Charts ---- */
+.chart { height: 360px; padding: 6px 8px; }
+.figure-cap { display: none; }
+.dingbat { display: none; }
+
+/* Panel actions / inline controls */
+.panel-actions { display: flex; align-items: center; gap: 6px; }
 .ghost-btn {
-  background: transparent;
-  border: 1px solid var(--rule);
-  color: var(--ink);
-  padding: 0.32rem 0.7rem;
-  border-radius: 999px;
-  font-family: -apple-system, 'Inter', sans-serif;
-  font-size: 0.66rem;
+  background: var(--bg-app);
+  border: 1px solid var(--border);
+  color: var(--text-1);
+  padding: 0 10px;
+  height: 22px;
+  border-radius: var(--radius);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  display: inline-flex; align-items: center; gap: 4px;
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s;
+}
+.ghost-btn:hover { background: var(--bg-panel-2); border-color: var(--border-strong); }
+.ghost-btn .pin-icon { font-size: 11px; line-height: 1; color: var(--accent); }
+.link-btn {
+  background: transparent; border: 0; padding: 0;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-3);
+  cursor: pointer;
+}
+.link-btn:hover:not(:disabled) { color: var(--link); }
+.link-btn:disabled { opacity: 0.35; cursor: default; }
+
+/* Pinned-runs panel */
+.pinned-panel {
+  margin: 0;
+  padding: 6px 10px 8px;
+  background: var(--bg-panel-2);
+  border-top: 1px solid var(--border);
+}
+.pinned-head {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 6px;
+}
+.pinned-title {
+  font-family: var(--font-mono);
+  font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-  display: inline-flex; align-items: center; gap: 0.35rem;
-  cursor: pointer;
-  transition: background 0.15s, color 0.15s, border-color 0.15s, transform 0.15s;
-}
-.ghost-btn:hover {
-  background: var(--ink); color: var(--bg);
-  border-color: var(--ink); transform: translateY(-1px);
-}
-.ghost-btn .pin-icon {
-  font-size: 0.78rem; line-height: 1;
-  color: var(--accent);
-  transition: color 0.15s ease;
-}
-.ghost-btn:hover .pin-icon { color: var(--bg); }
-.link-btn {
-  background: transparent; border: 0; padding: 0;
-  font-family: 'New York', ui-serif, Georgia, serif;
-  font-style: italic;
-  font-size: 0.84rem;
-  color: var(--muted);
-  cursor: pointer;
-}
-.link-btn:hover:not(:disabled) { color: var(--ink); text-decoration: underline; }
-.link-btn:disabled { opacity: 0.4; cursor: default; }
-
-/* ---- Pinned-runs panel (under equity chart) ---- */
-.pinned-panel {
-  margin: 1rem 0 0.4rem;
-  padding: 0.85rem 1rem;
-  background: var(--bg-tint);
-  border: 1px solid var(--rule);
-  border-radius: 4px;
-}
-.pinned-head {
-  display: flex; align-items: baseline; justify-content: space-between;
-  gap: 1rem; margin-bottom: 0.55rem;
-}
-.pinned-title {
-  font-family: -apple-system, 'Inter', sans-serif;
-  font-size: 0.62rem;
-  font-weight: 600;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--accent);
+  color: var(--text-2);
 }
 .pinned-empty {
-  margin: 0; padding: 0.1rem 0;
-  font-family: 'New York', ui-serif, Georgia, serif;
-  font-style: italic;
-  font-size: 0.9rem;
-  line-height: 1.55;
-  color: var(--muted);
+  margin: 0; padding: 0;
+  font-family: var(--font-sans);
+  font-size: 10.5px;
+  line-height: 1.45;
+  color: var(--text-3);
 }
-.pinned-empty em { color: var(--ink); font-weight: 500; }
+.pinned-empty em { color: var(--text-1); font-style: normal; font-weight: 500; }
 .pinned-list {
-  display: flex; flex-wrap: wrap; gap: 0.5rem;
+  display: flex; flex-wrap: wrap; gap: 4px;
 }
 .pinned-chip {
-  display: inline-flex; align-items: center; gap: 0.55rem;
-  padding: 0.35rem 0.55rem 0.35rem 0.45rem;
-  background: var(--bg);
-  border: 1px solid var(--rule);
-  border-radius: 999px;
-  max-width: 360px;
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 3px 6px 3px 5px;
+  background: var(--bg-app);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  max-width: 380px;
+  height: 24px;
 }
 .pinned-swatch {
-  width: 10px; height: 10px;
-  border-radius: 50%;
+  width: 8px; height: 8px;
+  border-radius: 0;
   flex-shrink: 0;
-  box-shadow: 0 0 0 1px var(--rule);
 }
 .pinned-body {
-  display: flex; flex-direction: column;
+  display: flex; align-items: center; gap: 8px;
   min-width: 0;
 }
 .pinned-label {
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 0.78rem;
-  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-1);
   font-variant-numeric: tabular-nums;
   cursor: text;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-  max-width: 260px;
+  max-width: 220px;
 }
 .pinned-label:hover { color: var(--accent); }
 .pinned-meta {
-  font-family: 'New York', ui-serif, Georgia, serif;
-  font-style: italic;
-  font-size: 0.72rem;
-  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-3);
   font-variant-numeric: tabular-nums;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 .pinned-restore, .pinned-remove {
-  background: transparent; border: 0; padding: 0;
-  font-family: -apple-system, 'Inter', sans-serif;
-  font-size: 0.95rem;
+  background: transparent; border: 0; padding: 0 2px;
+  font-family: var(--font-mono);
+  font-size: 11px;
   line-height: 1;
   cursor: pointer;
-  color: var(--muted);
-  transition: color 0.15s, transform 0.15s;
+  color: var(--text-3);
+  transition: color 0.1s;
 }
-.pinned-restore:hover { color: var(--accent); transform: rotate(-30deg); }
-.pinned-remove:hover  { color: var(--q); }
-
-/* ---- Charts (figures) ---- */
-.chart { height: 380px; }
-.figure-cap {
-  font-family: 'New York', ui-serif, Georgia, serif;
-  font-style: italic;
-  font-size: 0.88rem;
-  color: var(--muted);
-  margin: 0.7rem 0 0;
-  text-align: center;
-  line-height: 1.5;
-}
-.figure-cap .figno {
-  font-family: -apple-system, 'Inter', sans-serif;
-  font-style: normal;
-  font-size: 0.66rem;
-  font-weight: 600;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--accent);
-  margin-right: 0.55rem;
-  vertical-align: 0.15em;
-}
+.pinned-restore:hover { color: var(--accent); }
+.pinned-remove:hover  { color: var(--neg); }
 
 /* ---- Survivorship audit ---- */
 .audit-body {
   display: grid;
-  grid-template-columns: minmax(280px, 1fr) minmax(360px, 1.4fr);
-  gap: 1.6rem;
-  align-items: start;
+  grid-template-columns: minmax(260px, 1fr) minmax(360px, 1.6fr);
+  gap: 0;
+  padding: 0;
 }
 .audit-stats {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 0;
-  border-top: 1px solid var(--rule);
+  border-right: 1px solid var(--border);
+  align-content: start;
 }
 .audit-stats .a-cell {
-  padding: 0.7rem 0.85rem;
-  border-bottom: 1px solid var(--rule);
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
 }
-.audit-stats .a-cell:nth-child(odd) { border-right: 1px solid var(--rule); }
+.audit-stats .a-cell:nth-child(odd) { border-right: 1px solid var(--border); }
+.audit-stats .a-cell:nth-last-child(-n+2) { border-bottom: 0; }
 .audit-stats .a-label {
-  font-family: -apple-system, 'Inter', sans-serif;
-  font-size: 0.6rem;
-  font-weight: 600;
-  letter-spacing: 0.16em;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: var(--text-3);
 }
 .audit-stats .a-value {
-  font-family: 'New York', ui-serif, Georgia, serif;
-  font-size: 1.2rem;
+  font-family: var(--font-mono);
+  font-size: 14px;
   font-variant-numeric: tabular-nums;
-  margin-top: 0.25rem;
-  color: var(--ink);
+  margin-top: 2px;
+  color: var(--text-1);
 }
 .audit-stats .a-value.warn { color: var(--accent); }
-.audit-stats .a-value.bad  { color: var(--q); }
-.audit-chart { min-height: 220px; grid-row: 1 / span 2; grid-column: 2; }
+.audit-stats .a-value.bad  { color: var(--neg); }
+.audit-chart {
+  min-height: 200px;
+  padding: 6px 8px;
+}
 .audit-note {
   grid-column: 1 / -1;
-  margin: 0.6rem 0 0;
-  padding: 0.6rem 0 0.6rem 1.05rem;
-  border-left: 2px solid var(--ink);
-  font-family: 'New York', ui-serif, Georgia, serif;
-  font-style: italic;
-  font-size: 0.96rem;
-  line-height: 1.55;
-  color: var(--ink-soft);
+  margin: 0;
+  padding: 6px 12px;
+  border-top: 1px solid var(--border);
+  font-family: var(--font-sans);
+  font-size: 10.5px;
+  line-height: 1.45;
+  color: var(--text-2);
+  background: var(--bg-panel-2);
 }
 .audit-note::before {
-  content: "Note  ";
-  font-family: -apple-system, 'Inter', sans-serif;
-  font-style: normal;
+  content: "NOTE";
+  font-family: var(--font-mono);
   font-weight: 600;
-  font-size: 0.62rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--ink);
-  margin-right: 0.35rem;
+  font-size: 9.5px;
+  letter-spacing: 0.16em;
+  color: var(--accent);
+  margin-right: 8px;
 }
 @media (max-width: 900px) {
   .audit-body { grid-template-columns: 1fr; }
-  .audit-chart { grid-row: auto; grid-column: auto; }
-  .audit-stats .a-cell:nth-child(odd) { border-right: 0; }
+  .audit-stats { border-right: 0; border-bottom: 1px solid var(--border); }
 }
 
 /* ---- Data inspector ---- */
 .data-body {
   display: grid;
   grid-template-columns: minmax(420px, 1fr) minmax(360px, 1fr);
-  gap: 1.6rem;
+  gap: 0;
+}
+.data-left {
+  padding: 8px 10px;
+  border-right: 1px solid var(--border);
 }
 .search {
   width: 100%;
-  background: var(--bg-tint);
-  border: 1px solid var(--rule);
-  color: var(--ink);
-  padding: 0.5rem 0.75rem;
-  border-radius: 3px;
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 0.82rem;
-  margin-bottom: 0.7rem;
+  background: var(--bg-app);
+  border: 1px solid var(--border);
+  color: var(--text-1);
+  padding: 4px 8px;
+  border-radius: var(--radius);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  margin-bottom: 6px;
+  height: 24px;
 }
-.search:focus {
-  outline: none; border-color: var(--accent);
-  box-shadow: 0 0 0 2px var(--accent-tint);
-}
+.search:focus { outline: none; border-color: var(--link); }
 .table-wrap {
-  max-height: 380px;
+  max-height: 360px;
   overflow: auto;
-  border-top: 1px solid var(--rule);
-  border-bottom: 1px solid var(--rule);
-  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-app);
 }
 .ticker-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 0.82rem;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
   font-variant-numeric: tabular-nums;
 }
 .ticker-table thead th {
   position: sticky; top: 0;
-  background: var(--bg-tint);
-  font-family: -apple-system, 'Inter', sans-serif;
-  font-size: 0.6rem;
+  background: var(--bg-panel-2);
+  font-size: 9.5px;
   font-weight: 600;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--muted);
-  padding: 0.55rem 0.7rem;
-  border-bottom: 1px solid var(--rule);
+  color: var(--text-3);
+  padding: 5px 8px;
+  border-bottom: 1px solid var(--border);
   text-align: left;
+  z-index: 1;
 }
 .ticker-table tbody td {
-  padding: 0.42rem 0.7rem;
-  border-bottom: 1px solid var(--rule-soft);
-  color: var(--ink-soft);
+  padding: 3px 8px;
+  border-bottom: 1px solid var(--border-soft);
+  color: var(--text-1);
+  height: 22px;
 }
 .ticker-table tbody tr {
   cursor: pointer;
-  transition: background 0.1s;
+  transition: background 0.05s;
 }
-.ticker-table tbody tr:hover { background: var(--bg-tint); }
-.ticker-table tbody tr.active { background: var(--accent-tint); }
-.ticker-table .ret-pos { color: var(--k); }
-.ticker-table .ret-neg { color: var(--q); }
+.ticker-table tbody tr:hover { background: var(--bg-panel-2); }
+.ticker-table tbody tr.active { background: var(--accent-soft); }
+.ticker-table .ret-pos { color: var(--pos); }
+.ticker-table .ret-neg { color: var(--neg); }
 .ticker-table .tic-sym {
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  color: var(--ink);
+  font-family: var(--font-mono);
+  color: var(--text-1);
   font-weight: 600;
 }
 
 .data-right {
-  display: flex; flex-direction: column; gap: 0.7rem;
-  padding: 1rem 1.05rem;
-  background: var(--bg-tint);
-  border: 1px solid var(--rule);
-  border-radius: 3px;
+  display: flex; flex-direction: column; gap: 6px;
+  padding: 8px 10px;
+  background: var(--bg-panel);
   min-height: 380px;
 }
 .data-empty {
-  color: var(--muted);
-  font-family: 'New York', ui-serif, Georgia, serif;
-  font-style: italic;
-  font-size: 0.96rem;
+  color: var(--text-3);
+  font-family: var(--font-mono);
+  font-size: 11px;
   margin: auto;
+  letter-spacing: 0.04em;
 }
 .detail-head {
-  display: flex; align-items: baseline; gap: 0.7rem; flex-wrap: wrap;
+  display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap;
 }
 .detail-sym {
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 1.18rem; font-weight: 600;
-  color: var(--ink);
+  font-family: var(--font-mono);
+  font-size: 14px; font-weight: 600;
+  color: var(--accent);
+  letter-spacing: 0.04em;
 }
 .detail-name {
-  font-family: 'New York', ui-serif, Georgia, serif;
-  font-size: 1rem; color: var(--ink);
+  font-family: var(--font-sans);
+  font-size: 11.5px;
+  color: var(--text-2);
 }
 .detail-meta {
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 0.74rem;
-  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-3);
   font-variant-numeric: tabular-nums;
+  word-break: break-all;
 }
 .detail-stats {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 0;
-  border-top: 1px solid var(--rule);
-  border-bottom: 1px solid var(--rule);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
 }
 .detail-stats .s-cell {
-  padding: 0.55rem 0.7rem;
-  border-right: 1px solid var(--rule);
+  padding: 4px 8px;
+  border-right: 1px solid var(--border);
 }
 .detail-stats .s-cell:nth-child(3n) { border-right: 0; }
 .detail-stats .s-label {
-  font-family: -apple-system, 'Inter', sans-serif;
-  font-size: 0.6rem;
-  font-weight: 600;
-  letter-spacing: 0.16em;
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: var(--text-3);
 }
 .detail-stats .s-value {
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 0.86rem;
+  font-family: var(--font-mono);
+  font-size: 12px;
   font-variant-numeric: tabular-nums;
-  margin-top: 0.2rem;
-  color: var(--ink);
+  margin-top: 1px;
+  color: var(--text-1);
 }
-.detail-chart { flex: 1; min-height: 320px; }
+.detail-chart { flex: 1; min-height: 280px; }
 
-/* ---- Dingbat divider (between major sections) ---- */
-.dingbat {
-  text-align: center;
-  font-family: 'New York', ui-serif, Georgia, serif;
-  color: var(--muted);
-  font-size: 1.3rem;
-  margin: 1rem 0 2rem;
-  letter-spacing: 0.55em;
-  user-select: none;
-}
-
-/* ---- Status + toast ---- */
+/* ---- Status bar ---- */
 .statusbar {
   position: fixed;
   bottom: 0; left: 0; right: 0;
-  padding: 0.4rem 1.2rem;
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  font-size: 0.72rem;
-  color: var(--muted);
-  background: var(--bg);
-  border-top: 1px solid var(--rule);
+  padding: 4px 14px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-3);
+  background: var(--bg-panel);
+  border-top: 1px solid var(--border);
   z-index: 10;
   font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+  height: 22px;
+  display: flex; align-items: center;
 }
-.statusbar.ready   { color: var(--k); }
+.statusbar.ready   { color: var(--pos); }
 .statusbar.loading { color: var(--accent); }
-.statusbar.error   { color: var(--q); }
+.statusbar.error   { color: var(--neg); }
+.statusbar::before {
+  content: "▸";
+  color: var(--text-mute);
+  margin-right: 6px;
+}
 
 .toast {
   position: fixed;
-  bottom: 36px;
+  bottom: 32px;
   left: 50%;
   transform: translateX(-50%);
-  background: var(--ink);
-  color: var(--bg);
-  padding: 0.55rem 1.1rem;
-  border-radius: 3px;
-  font-family: -apple-system, 'Inter', sans-serif;
-  font-size: 0.78rem;
-  letter-spacing: 0.01em;
-  box-shadow: 0 4px 16px rgba(17,19,26,0.18);
+  background: var(--bg-elevated);
+  color: var(--text-1);
+  padding: 6px 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.02em;
   z-index: 20;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+  max-width: 80vw;
 }
 .toast.hidden { display: none; }
-.toast.error  { background: var(--q); color: #fff; }
+.toast.error  { border-color: var(--neg); color: var(--neg); }
 
 /* ---- Responsive ---- */
 @media (max-width: 1100px) {
-  .topbar { grid-template-columns: auto 1fr auto auto; padding: 1.1rem 1.4rem 0.9rem; }
-  .topbar .strategy-tabs { grid-column: 1 / -1; justify-self: start; gap: 1.1rem; }
+  .topbar { grid-template-columns: auto 1fr auto; padding: 6px 10px; }
+  .topbar .strategy-tabs { grid-column: 1 / -1; justify-self: start; }
   .topbar .horizon { grid-column: 1 / -1; justify-self: start; }
   .topbar .source-picker { grid-column: 3; }
-  .theme-toggle { grid-column: 4; }
-  .layout { padding: 2rem 1.4rem 4rem; }
-  .app-split { grid-template-columns: 1fr; gap: 2.2rem; }
-  .sidebar { position: static; max-height: none; overflow: visible; padding-right: 0; }
+  .layout { padding: 8px 10px 36px; }
+  .app-split { grid-template-columns: 1fr; gap: 8px; }
+  .sidebar { position: static; max-height: none; overflow: visible; }
   .metrics-strip { grid-template-columns: repeat(2, 1fr); }
-  .metrics-strip .m-card { border-bottom: 1px solid var(--rule); }
+  .metrics-strip .m-card { border-bottom: 1px solid var(--border); }
   .metrics-strip .m-card:nth-child(2n) { border-right: 0; }
   .metrics-strip .m-card:nth-last-child(-n+2) { border-bottom: 0; }
   .data-body { grid-template-columns: 1fr; }
+  .data-left { border-right: 0; border-bottom: 1px solid var(--border); }
 }
 @media (max-width: 720px) {
-  html { font-size: 15.5px; }
-  .topbar { padding: 1rem 1rem 0.7rem; gap: 0.8rem; row-gap: 0.7rem; }
-  .layout { padding: 1.6rem 1rem 4rem; }
-  .panel { margin-bottom: 2.4rem; }
-  .panel-head { flex-direction: column; align-items: flex-start; gap: 0.2rem; }
-  .panel-sub { text-align: left; }
-  .metrics-strip { grid-template-columns: 1fr 1fr; }
+  html { font-size: 13px; }
+  .topbar { padding: 5px 8px; gap: 8px; }
+  .panel-head { padding: 5px 8px; }
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Summary

Replace the editorial-whitepaper aesthetic with a dense, dark trading terminal. Quant traders want numbers, not magazine layouts.

- Mantine-dark palette (#0d0e10 / #131418 / #2a2c33), JetBrains-Mono dominant
- 1px hairlines everywhere, no shadows, no decoration
- Gold accent for selected/active state only; blue for interactive; red/green for P&L only
- Dropped: theme toggle, section markers (§ I/II), dingbat dividers, figure captions, serif prose
- Pinned overlay rotation deliberately avoids red/green so P&L semantics stay clean
- All functionality preserved (Pin to overlay, source picker, ↺ reset, conditional log y-axis, Wharton toggle)

References: IMC Prosperity Visualizer, WorldQuant BRAIN, Bloomberg Terminal density.

## Test plan

- [ ] Vercel rebuilds and serves the new dark UI at https://cds-millennium-backtester.vercel.app/
- [ ] Run a backtest — metrics + chart populated, monospace numerics
- [ ] Pin two runs at different lookbacks — overlay shows live (blue) + pinned (gold/violet) curves cleanly
- [ ] Switch data source to Wharton — universe label updates, ~830 tickers
- [ ] Open AAPL in the data inspector — log y-axis with readable ticks