### PR TITLE
feat(simulation): expand strategy catalog, combined generator, header polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ data_cache/
 sp500_universe.pkl
 .claude/
 data_quality_materials/
+.gstack/

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ from strategies.mean_reversion import MeanReversionOrderGenerator
 from strategies.momentum_strategy import MomentumOrderGenerator
 from strategies.pairs_trading import PairsTradingOrderGenerator
 from strategies.moving_avg import MovingAverageOrderGenerator
+from strategies.combined import build_default_combined
 from backtester.backtest_engine import EquityBacktestEngine
 from backtester.metrics import ExtendedMetrics
 
@@ -19,6 +20,7 @@ STRATEGIES = {
     "2": "Momentum",
     "3": "Pairs Trading",
     "4": "Moving Average",
+    "5": "Combined (all strategies, equal weight)",
 }
 
 DATA_SOURCES = {
@@ -199,6 +201,38 @@ def build_strategy(choice, tickers):
         print(">> Moving Average (5-day vs. 20-day rolling windows)")
         return MovingAverageOrderGenerator(), tickers
 
+    elif choice == "5":
+        raw_pairs = input("Pairs for the pairs sub-strategy (default: KO/PEP, V/MA): ").strip()
+        if raw_pairs:
+            pairs = []
+            for p in raw_pairs.split(","):
+                a, b = p.strip().split("/")
+                pairs.append((a.strip().upper(), b.strip().upper()))
+        else:
+            pairs = [("KO", "PEP"), ("V", "MA")]
+
+        capiq_path = input(
+            "Optional CapIQ relationship file for Customer-Supplier Momentum "
+            "(leave blank to skip): "
+        ).strip() or None
+        if capiq_path and not os.path.exists(capiq_path):
+            print(f"CapIQ file not found at {capiq_path!r}. Skipping that sub-strategy.")
+            capiq_path = None
+
+        all_tickers = list(tickers)
+        for a, b in pairs:
+            if a not in all_tickers:
+                all_tickers.append(a)
+            if b not in all_tickers:
+                all_tickers.append(b)
+
+        n_subs = 5 if capiq_path else 4
+        print(
+            f">> Combined: {n_subs} sub-strategies, equal-weight (1/{n_subs} each), "
+            f"pairs={pairs}, capiq={'on' if capiq_path else 'off'}"
+        )
+        return build_default_combined(pairs=pairs, capiq_path=capiq_path), all_tickers
+
     else:
         print("Invalid choice.")
         sys.exit(1)
@@ -209,7 +243,7 @@ def main():
     for key, name in STRATEGIES.items():
         print(f"  {key}. {name}")
 
-    choice = input("\nSelect a strategy [1-4]: ").strip()
+    choice = input("\nSelect a strategy [1-5]: ").strip()
     if choice not in STRATEGIES:
         print("Invalid selection.")
         return

--- a/simulation/backend/server.py
+++ b/simulation/backend/server.py
@@ -16,7 +16,7 @@ import threading
 import traceback
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(ROOT))
@@ -43,6 +43,38 @@ def _kick_warmup_async(source: str = None) -> None:
             traceback.print_exc()
 
     threading.Thread(target=_run, daemon=True).start()
+
+
+def _query_source(parsed) -> str | None:
+    values = parse_qs(parsed.query).get("source", [])
+    return values[0] if values else None
+
+
+def _validate_source(source: str | None) -> None:
+    if source and source not in simulator.SUPPORTED_SOURCES:
+        raise ValueError(f"unknown data source: {source!r}")
+
+
+def _prepare_warmup(source: str | None) -> None:
+    if not source:
+        return
+    with simulator._LOCK:
+        current = simulator._STATE.get("data_source")
+        if current == source and (simulator._STATE["ready"] or simulator._STATE["loading"]):
+            return
+        simulator._STATE["ready"] = False
+        simulator._STATE["loading"] = False
+        simulator._STATE["dataset"] = None
+        simulator._STATE["benchmark"] = None
+        simulator._STATE["date_min"] = None
+        simulator._STATE["date_max"] = None
+        simulator._STATE["tickers"] = 0
+        simulator._STATE["universe_label"] = None
+        simulator._STATE["error"] = None
+        simulator._STATE["message"] = f"loading {source} dataset"
+        simulator._STATE["data_source"] = source
+        simulator._STATE["load_token"] = int(simulator._STATE.get("load_token", 0)) + 1
+    simulator._SIM_CACHE.clear()
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -81,7 +113,15 @@ class Handler(BaseHTTPRequestHandler):
         path = parsed.path
 
         if path == "/api/status":
-            self._send_json(simulator.status())
+            requested_source = _query_source(parsed)
+            try:
+                _validate_source(requested_source)
+                if requested_source:
+                    _prepare_warmup(requested_source)
+                    _kick_warmup_async(source=requested_source)
+                self._send_json(simulator.status(source=requested_source))
+            except ValueError as exc:
+                self._send_json({"error": str(exc)}, status=400)
             return
 
         if path == "/api/catalog":
@@ -89,18 +129,25 @@ class Handler(BaseHTTPRequestHandler):
             return
 
         if path == "/api/data":
+            requested_source = _query_source(parsed)
             try:
-                self._send_json(simulator.data_overview())
+                _validate_source(requested_source)
+                self._send_json(simulator.data_overview(source=requested_source))
+            except ValueError as exc:
+                self._send_json({"error": str(exc)}, status=400)
             except RuntimeError as exc:
                 self._send_json({"error": str(exc)}, status=409)
             return
 
         if path.startswith("/api/data/ticker/"):
+            requested_source = _query_source(parsed)
             tic = path.split("/api/data/ticker/", 1)[1]
             try:
-                self._send_json(simulator.ticker_detail(tic))
+                _validate_source(requested_source)
+                self._send_json(simulator.ticker_detail(tic, source=requested_source))
             except ValueError as exc:
-                self._send_json({"error": str(exc)}, status=404)
+                status = 400 if str(exc).startswith("unknown data source") else 404
+                self._send_json({"error": str(exc)}, status=status)
             except RuntimeError as exc:
                 self._send_json({"error": str(exc)}, status=409)
             return
@@ -131,22 +178,13 @@ class Handler(BaseHTTPRequestHandler):
 
         if path == "/api/warmup":
             requested_source = body.get("source") if isinstance(body, dict) else None
-            current = simulator.status().get("data_source")
-            # Switching to a different source needs to drop the loaded
-            # dataset so warmup actually reloads. simulator.warmup is a
-            # no-op when ready and the source matches, so we explicitly
-            # invalidate _STATE here when the user picks a different one.
-            if requested_source and requested_source != current:
-                with simulator._LOCK:
-                    simulator._STATE["ready"] = False
-                    simulator._STATE["loading"] = False
-                    simulator._STATE["dataset"] = None
-                    simulator._STATE["benchmark"] = None
-                    simulator._STATE["error"] = None
-                    simulator._STATE["data_source"] = requested_source
-                simulator._SIM_CACHE.clear()
-            _kick_warmup_async(source=requested_source)
-            self._send_json(simulator.status())
+            try:
+                _validate_source(requested_source)
+                _prepare_warmup(requested_source)
+                _kick_warmup_async(source=requested_source)
+                self._send_json(simulator.status(source=requested_source))
+            except ValueError as exc:
+                self._send_json({"error": str(exc)}, status=400)
             return
 
         if path == "/api/universe/add":

--- a/simulation/backend/simulator.py
+++ b/simulation/backend/simulator.py
@@ -765,8 +765,24 @@ def run_simulation(body: Dict[str, Any]) -> Dict[str, Any]:
     net_cum = (1 + result.net_returns.fillna(0)).cumprod() - 1
     bench_cum = (1 + benchmark.reindex(result.net_returns.index).fillna(0)).cumprod() - 1
 
+    # Drawdown curve — fraction underwater from running peak. Same formula
+    # as backtester/tearsheet.py:38 but emitted as a JSON-friendly list.
+    net_dd = (net_cum.add(1) / net_cum.add(1).cummax() - 1)
+    bench_dd = (bench_cum.add(1) / bench_cum.add(1).cummax() - 1)
+
     turnover_ann = float(result.turnover.mean() * 252)
     tcost_drag_ann = float(result.transaction_costs.mean() * 252)
+
+    # Monthly returns — port of backtester/tearsheet.py:76. Emit a list of
+    # {year, month, ret} cells so the frontend can pivot it into a heatmap.
+    monthly_ret = (
+        result.net_returns.resample("ME").apply(lambda r: (1 + r).prod() - 1)
+    )
+    monthly_payload = [
+        {"year": int(d.year), "month": int(d.month), "ret": float(v)}
+        for d, v in monthly_ret.items()
+        if pd.notna(v)
+    ]
 
     response = {
         "strategy": {
@@ -778,6 +794,9 @@ def run_simulation(body: Dict[str, Any]) -> Dict[str, Any]:
         "dates": [d.strftime("%Y-%m-%d") for d in result.net_returns.index],
         "cumulative_net": [float(v) for v in net_cum.values],
         "cumulative_benchmark": [float(v) for v in bench_cum.values],
+        "cumulative_drawdown": [float(v) for v in net_dd.values],
+        "cumulative_drawdown_benchmark": [float(v) for v in bench_dd.values],
+        "monthly_returns": monthly_payload,
         "metrics_net": _metrics(
             result.net_returns,
             benchmark=benchmark.reindex(result.net_returns.index).fillna(0),

--- a/simulation/backend/simulator.py
+++ b/simulation/backend/simulator.py
@@ -16,9 +16,10 @@ import hashlib
 import inspect
 import json
 import threading
+import time
 from datetime import date
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 import pandas as pd
@@ -45,6 +46,7 @@ _STATE: Dict[str, Any] = {
     "date_min": None, "date_max": None, "tickers": 0,
     "universe_label": None,
     "data_source": DEFAULT_SOURCE,
+    "load_token": 0,
 }
 _SIM_CACHE: Dict[str, Dict[str, Any]] = {}
 
@@ -83,12 +85,19 @@ def _clean_strategy_source(src: str) -> str:
 # ---------------------------------------------------------------------------
 # Catalog — declarative, each field mirrors an actual line of source
 # ---------------------------------------------------------------------------
+_SHORT_QUANTILE_OVERRIDE = {
+    "name": "short_quantile", "type": "float", "default": 0.0,
+    "min": 0.0, "max": 0.40, "step": 0.05,
+    "help": "Bottom fraction sold short (0 = long-only, >0 turns the sleeve into long-short).",
+}
+
 STRATEGIES = [
     {
         "id": "momentum",
         "cls": rs.CrossSectionalMomentumStrategy,
         "cls_name": "CrossSectionalMomentumStrategy",
         "label": "Momentum",
+        "formula": "score(t, i) = ln( P[t − skip, i] / P[t − lookback, i] )",
         "summary": "Rank stocks by their return from (today − lookback_days) to (today − skip_days); long the top quantile, optionally short the bottom.",
         "params": [
             {"name": "lookback_days", "type": "int", "default": 126, "min": 21, "max": 504, "step": 21,
@@ -96,22 +105,69 @@ STRATEGIES = [
             {"name": "skip_days",     "type": "int", "default": 21,  "min": 0,  "max": 63,  "step": 1,
              "help": "Skip last N days to drop short-term reversal (21 ≈ 1mo)."},
         ],
-        "engine_overrides": [
-            {"name": "short_quantile", "type": "float", "default": 0.0, "min": 0.0, "max": 0.40, "step": 0.05,
-             "help": "Bottom fraction sold short (0 = long-only, long-short becomes dollar-neutral)."},
-        ],
+        "engine_overrides": [_SHORT_QUANTILE_OVERRIDE],
     },
     {
         "id": "mean_reversion",
         "cls": rs.ShortTermReversalStrategy,
         "cls_name": "ShortTermReversalStrategy",
         "label": "Mean Reversion",
+        "formula": "score(t, i) = − ln( P[t, i] / P[t − lookback, i] )",
         "summary": "Score stocks by their negated recent return; long the biggest recent losers, expecting a bounce.",
         "params": [
             {"name": "lookback_days", "type": "int", "default": 5, "min": 1, "max": 21, "step": 1,
              "help": "Recent-return window; biggest losers rank highest."},
         ],
-        "engine_overrides": [],
+        "engine_overrides": [_SHORT_QUANTILE_OVERRIDE],
+    },
+    {
+        "id": "moving_average",
+        "cls": rs.MovingAverageCrossoverStrategy,
+        "cls_name": "MovingAverageCrossoverStrategy",
+        "label": "Moving Average",
+        "formula": "score(t, i) = EMA_short(P, t, i) / EMA_long(P, t, i) − 1",
+        "summary": "Cross-sectional EMA crossover — score = (short EMA − long EMA) / long EMA. Long names in the strongest uptrend, short the weakest.",
+        "params": [
+            {"name": "short_window", "type": "int", "default": 50,  "min": 5,  "max": 100, "step": 5,
+             "help": "Span of the fast EMA."},
+            {"name": "long_window",  "type": "int", "default": 200, "min": 50, "max": 400, "step": 10,
+             "help": "Span of the slow EMA."},
+        ],
+        "engine_overrides": [_SHORT_QUANTILE_OVERRIDE],
+    },
+    {
+        "id": "customer_supplier_momentum",
+        "cls": rs.CustomerSupplierMomentumStrategy,
+        "cls_name": "CustomerSupplierMomentumStrategy",
+        "label": "Customer-Supplier Momentum",
+        "formula": "score(t, i) = mean over j ∈ customers(i) of ln( P[t, j] / P[t − lookback, j] )",
+        "summary": "Cohen & Frazzini (2008). Long suppliers whose major customers had strong recent returns; short those tied to weak customers. Uses a curated supplier→customer map.",
+        "params": [
+            {"name": "customer_lookback_days", "type": "int", "default": 21, "min": 5, "max": 63, "step": 1,
+             "help": "Recent-return window on the customer side (21 ≈ 1mo)."},
+            {"name": "min_customers", "type": "int", "default": 1, "min": 1, "max": 5, "step": 1,
+             "help": "Minimum customers with valid returns required to score a supplier."},
+        ],
+        "engine_overrides": [
+            {**_SHORT_QUANTILE_OVERRIDE, "default": 0.20,
+             "help": "Bottom fraction (suppliers tied to weak customers) sold short."},
+        ],
+    },
+    {
+        "id": "pead",
+        "cls": rs.PEADStrategy,
+        "cls_name": "PEADStrategy",
+        "label": "Post-Earnings Announcement Drift",
+        "formula": "score(t, i) = SUE(announce(i))   for t ∈ [announce(i), announce(i) + holding]",
+        "summary": "Bernard & Thomas (1989). On each ticker's announcement date set score = SUE; hold for `holding_days`. Long top decile, short bottom decile.",
+        "params": [
+            {"name": "holding_days", "type": "int", "default": 60, "min": 5, "max": 90, "step": 5,
+             "help": "Trading days to keep the SUE signal active after the announcement."},
+        ],
+        "engine_overrides": [
+            {**_SHORT_QUANTILE_OVERRIDE, "default": 0.10,
+             "help": "Bottom-decile (negative SUE) names sold short — recovers the canonical long-short PEAD sleeve."},
+        ],
     },
 ]
 STRATEGY_BY_ID = {s["id"]: s for s in STRATEGIES}
@@ -149,6 +205,15 @@ FIXED_ENGINE = {
 # ---------------------------------------------------------------------------
 # Warmup — load the chosen data source into a ResearchDataset
 # ---------------------------------------------------------------------------
+def _normalise_source(source: str = None) -> str:
+    if source is None:
+        source = _STATE.get("data_source") or DEFAULT_SOURCE
+    source = str(source).strip().lower()
+    if source not in SUPPORTED_SOURCES:
+        raise ValueError(f"unknown data source: {source!r}")
+    return source
+
+
 def _normalize_wharton_columns(panel):
     """Wharton/Compustat tickers use dot notation (BRK.B, BF.B); the rest of
     the simulator (and the frontend) speaks dash notation (BRK-B). Rename
@@ -198,16 +263,15 @@ def _load_wharton_dataset(start: str, end: str) -> ResearchDataset:
 def warmup(start: str = "2005-01-01", end: str = None, source: str = None) -> None:
     if end is None:
         end = date.today().strftime("%Y-%m-%d")
-    if source is None:
-        source = _STATE.get("data_source") or DEFAULT_SOURCE
-    if source not in SUPPORTED_SOURCES:
-        raise ValueError(f"unknown data source: {source!r}")
+    source = _normalise_source(source)
     with _LOCK:
-        if _STATE["loading"]:
+        if _STATE["loading"] and _STATE.get("data_source") == source:
             return
         # If the requested source matches the already-loaded one, nothing to do.
         if _STATE["ready"] and _STATE.get("data_source") == source:
             return
+        token = int(_STATE.get("load_token", 0)) + 1
+        _STATE["load_token"] = token
         _STATE["loading"] = True
         _STATE["ready"] = False
         _STATE["data_source"] = source
@@ -238,6 +302,8 @@ def warmup(start: str = "2005-01-01", end: str = None, source: str = None) -> No
         # different universe → identical request would otherwise stale-hit).
         _SIM_CACHE.clear()
         with _LOCK:
+            if token != _STATE.get("load_token") or _STATE.get("data_source") != source:
+                return
             _STATE.update({
                 "ready": True, "loading": False, "message": "ready",
                 "dataset": dataset, "benchmark": dataset.benchmark_returns,
@@ -249,15 +315,39 @@ def warmup(start: str = "2005-01-01", end: str = None, source: str = None) -> No
             })
     except Exception as exc:
         with _LOCK:
+            if token != _STATE.get("load_token") or _STATE.get("data_source") != source:
+                return
             _STATE["loading"] = False
             _STATE["error"] = str(exc)
             _STATE["message"] = f"error: {exc}"
         raise
 
 
-def status() -> Dict[str, Any]:
+def ensure_ready(source: str = None, timeout: float = 120.0) -> None:
+    """Block until the requested data source is loaded on this worker."""
+    source = _normalise_source(source)
+    deadline = time.monotonic() + timeout
+    while True:
+        with _LOCK:
+            ready = _STATE["ready"] and _STATE.get("data_source") == source
+            loading = _STATE["loading"] and _STATE.get("data_source") == source
+            error = _STATE["error"] if _STATE.get("data_source") == source else None
+        if ready:
+            return
+        if error and not loading:
+            raise RuntimeError(error)
+        if time.monotonic() > deadline:
+            raise RuntimeError(f"timed out loading {source} dataset")
+        if loading:
+            time.sleep(0.25)
+            continue
+        warmup(source=source)
+
+
+def status(source: str = None) -> Dict[str, Any]:
+    requested_source = _normalise_source(source) if source else None
     with _LOCK:
-        return {
+        payload = {
             "ready": _STATE["ready"], "loading": _STATE["loading"],
             "message": _STATE["message"], "error": _STATE["error"],
             "date_min": _STATE["date_min"], "date_max": _STATE["date_max"],
@@ -266,6 +356,17 @@ def status() -> Dict[str, Any]:
             "data_source": _STATE.get("data_source", DEFAULT_SOURCE),
             "available_sources": list(SUPPORTED_SOURCES),
         }
+    if requested_source and payload["data_source"] != requested_source:
+        payload["ready"] = False
+        payload["loading"] = True
+        payload["message"] = f"loading {requested_source} dataset"
+        payload["error"] = None
+        payload["date_min"] = None
+        payload["date_max"] = None
+        payload["tickers"] = 0
+        payload["universe_label"] = None
+        payload["data_source"] = requested_source
+    return payload
 
 
 # ---------------------------------------------------------------------------
@@ -280,6 +381,7 @@ def catalog() -> Dict[str, Any]:
             "label": entry["label"],
             "cls_name": entry["cls_name"],
             "summary": entry["summary"],
+            "formula": entry.get("formula", ""),
             "params": entry["params"],
             "engine_overrides": entry.get("engine_overrides", []),
             "source": src,
@@ -301,22 +403,66 @@ def _cache_key(payload: Dict[str, Any]) -> str:
     return hashlib.md5(json.dumps(payload, sort_keys=True, default=str).encode()).hexdigest()
 
 
-def _metrics(returns: pd.Series) -> Dict[str, float]:
+def _metrics(returns: pd.Series, benchmark: Optional[pd.Series] = None) -> Dict[str, float]:
     clean = returns.dropna()
     if len(clean) < 2:
         return {}
     cum = (1 + clean).cumprod()
-    ann_ret = cum.iloc[-1] ** (252 / len(clean)) - 1
-    std = clean.std(ddof=0)
-    sharpe = clean.mean() / std * np.sqrt(252) if std > 0 else 0.0
-    dd = (cum / cum.cummax() - 1).min()
-    return {
-        "annualized_return": float(ann_ret),
-        "annualized_volatility": float(std * np.sqrt(252)),
-        "sharpe": float(sharpe),
-        "max_drawdown": float(dd),
+    ann_ret = float(cum.iloc[-1] ** (252 / len(clean)) - 1)
+    std = float(clean.std(ddof=0))
+    ann_vol = float(std * np.sqrt(252))
+    sharpe = float(clean.mean() / std * np.sqrt(252)) if std > 0 else 0.0
+    dd = float((cum / cum.cummax() - 1).min())
+
+    # Sortino — only penalize downside deviation. Treat zero-only-positives
+    # as infinite Sortino by capping at the Sharpe value (shouldn't happen
+    # on a real strategy but guards against div-by-zero).
+    downside = clean[clean < 0]
+    downside_std = float(downside.std(ddof=0)) if len(downside) > 1 else 0.0
+    sortino = float(clean.mean() / downside_std * np.sqrt(252)) if downside_std > 0 else 0.0
+
+    # Calmar — annualized return / abs(max drawdown). Undefined when
+    # drawdown is exactly zero; report None rather than infinity.
+    calmar = float(ann_ret / abs(dd)) if dd < 0 else None
+
+    # Profit factor — sum of positive returns / abs(sum of negatives)
+    pos_sum = float(clean[clean > 0].sum())
+    neg_sum = float(abs(clean[clean < 0].sum()))
+    profit_factor = float(pos_sum / neg_sum) if neg_sum > 0 else None
+
+    out: Dict[str, Any] = {
+        "annualized_return": ann_ret,
+        "annualized_volatility": ann_vol,
+        "sharpe": sharpe,
+        "max_drawdown": dd,
         "win_rate": float((clean > 0).mean()),
+        "hit_rate": float((clean > 0).mean()),       # alias — quants prefer "hit rate"
+        "sortino": sortino,
+        "calmar": calmar,
+        "profit_factor": profit_factor,
     }
+
+    # Benchmark-relative — Information Ratio + Beta. Only meaningful when
+    # we actually have an aligned benchmark series.
+    if benchmark is not None:
+        aligned = pd.concat([clean, benchmark], axis=1, join="inner").dropna()
+        if len(aligned) >= 2:
+            aligned.columns = ["s", "b"]
+            active = aligned["s"] - aligned["b"]
+            active_std = float(active.std(ddof=0))
+            info_ratio = float(active.mean() / active_std * np.sqrt(252)) if active_std > 0 else 0.0
+            bench_var = float(aligned["b"].var(ddof=0))
+            beta = float(aligned[["s", "b"]].cov().iat[0, 1] / bench_var) if bench_var > 0 else 0.0
+            out["info_ratio"] = info_ratio
+            out["beta"] = beta
+        else:
+            out["info_ratio"] = None
+            out["beta"] = None
+    else:
+        out["info_ratio"] = None
+        out["beta"] = None
+
+    return out
 
 
 def _normalise_tickers(raw) -> List[str]:
@@ -399,7 +545,68 @@ def add_tickers_to_universe(tickers: List[str]) -> Dict[str, Any]:
     }
 
 
+_MAX_OVERRIDE_SIZE = 64 * 1024  # 64 KB cap on user-edited source — keeps exec() bounded.
+
+
+def _compile_strategy_override(source: str, fallback_cls):
+    """Compile a user-edited SignalStrategy class definition and return the
+    resulting class. Re-executes only the class body — module-level imports
+    are pre-populated in the namespace so the user doesn't have to repeat
+    them. Falls back to ``fallback_cls`` on parse errors with a helpful
+    error message.
+    """
+    if not isinstance(source, str):
+        raise ValueError("strategy_source_override must be a string")
+    if len(source) > _MAX_OVERRIDE_SIZE:
+        raise ValueError(
+            f"strategy_source_override too large ({len(source)} bytes; max {_MAX_OVERRIDE_SIZE})"
+        )
+    # Strip ANY 'from ... import' / 'import' lines that would re-import the
+    # module — the namespace already has everything they need, and re-imports
+    # can shadow our SignalStrategy ABC, which breaks subclass detection.
+    namespace: Dict[str, Any] = {
+        "__builtins__": __builtins__,
+        "pd": pd, "np": np,
+        "pandas": pd, "numpy": np,
+        "ResearchDataset": ResearchDataset,
+    }
+    # Re-export every name from research_strategies so the user can call
+    # _cross_sectional_zscore, reference SignalStrategy, etc.
+    from strategies import research_strategies as _rs_mod
+    for attr in dir(_rs_mod):
+        if not attr.startswith("_") or attr == "_cross_sectional_zscore" or attr == "_sector_neutral_zscore":
+            namespace.setdefault(attr, getattr(_rs_mod, attr))
+    namespace["SignalStrategy"] = _rs_mod.SignalStrategy
+    try:
+        compiled = compile(source, "<live-edit>", "exec")
+        exec(compiled, namespace)
+    except SyntaxError as exc:
+        raise ValueError(f"syntax error in edited code (line {exc.lineno}): {exc.msg}") from exc
+    except Exception as exc:
+        raise ValueError(f"error executing edited code: {exc}") from exc
+    # Find the SignalStrategy subclass the user defined (skip the imported
+    # ABC itself, and skip the fallback class which is also in the namespace).
+    candidates = [
+        v for v in namespace.values()
+        if isinstance(v, type)
+        and issubclass(v, _rs_mod.SignalStrategy)
+        and v is not _rs_mod.SignalStrategy
+        and v is not fallback_cls
+    ]
+    if not candidates:
+        raise ValueError(
+            "edited code did not define a new SignalStrategy subclass. "
+            "Keep the `class XxxStrategy(SignalStrategy):` declaration."
+        )
+    # Prefer the LAST candidate so a user editing multiple class blocks gets
+    # the bottom-most one (matches Python class-redefinition semantics).
+    return candidates[-1]
+
+
 def run_simulation(body: Dict[str, Any]) -> Dict[str, Any]:
+    requested_source = body.get("data_source") or body.get("source")
+    if requested_source:
+        ensure_ready(requested_source)
     # Snapshot the shared dataset under the lock so a concurrent
     # add_tickers_to_universe rebuild can't swap the panel out from under us
     # mid-run (KeyError on dropped columns, stale prices, etc.).
@@ -434,20 +641,43 @@ def run_simulation(body: Dict[str, Any]) -> Dict[str, Any]:
             )
     start = body.get("start") or date_min
     end = body.get("end") or date_max
+    start_ts = pd.Timestamp(start)
+    end_ts = pd.Timestamp(end)
+    if start_ts > end_ts:
+        raise ValueError(f"start date must be on or before end date ({start} > {end})")
 
-    # Strategy constructor args (whitelisted)
+    # Strategy constructor args (whitelisted to the catalog params).
     kw_allowed = {p["name"] for p in strat_entry["params"]}
     strat_kwargs = {k: strategy_params[k] for k in kw_allowed if k in strategy_params}
-    strat_instance = strat_entry["cls"](**strat_kwargs)
 
-    # BacktestConfig: fixed defaults + global engine knobs + per-strategy overrides
+    # Live-code override: if the body carries an edited class definition,
+    # compile it on the fly and use it instead of the catalog class. The
+    # catalog params still drive the constructor — but the user's class may
+    # accept fewer/more kwargs, so we filter to whatever the new class
+    # actually exposes.
+    source_override = body.get("strategy_source_override")
+    edited_cls_name: Optional[str] = None
+    if source_override:
+        live_cls = _compile_strategy_override(source_override, fallback_cls=strat_entry["cls"])
+        edited_cls_name = live_cls.__name__
+        sig = inspect.signature(live_cls.__init__)
+        accepted = {name for name in sig.parameters if name != "self"}
+        live_kwargs = {k: v for k, v in strat_kwargs.items() if k in accepted}
+        try:
+            strat_instance = live_cls(**live_kwargs)
+        except TypeError as exc:
+            raise ValueError(f"edited class constructor rejected the catalog params: {exc}") from exc
+    else:
+        strat_instance = strat_entry["cls"](**strat_kwargs)
+
+    # BacktestConfig: fixed defaults + global engine knobs (defaults seeded
+    # from the catalog so the response config block is always populated, even
+    # when the caller omits engine_params entirely) + per-strategy overrides.
     cfg_kwargs = dict(FIXED_ENGINE)
     for p in ENGINE_PARAMS:
-        if p["name"] in engine_params:
-            cfg_kwargs[p["name"]] = engine_params[p["name"]]
+        cfg_kwargs[p["name"]] = engine_params.get(p["name"], p["default"])
     for p in strat_entry.get("engine_overrides", []):
-        if p["name"] in engine_overrides_in:
-            cfg_kwargs[p["name"]] = engine_overrides_in[p["name"]]
+        cfg_kwargs[p["name"]] = engine_overrides_in.get(p["name"], p["default"])
     # Auto-flip long_only based on short_quantile — a positive short leg
     # means we actually want to short (otherwise build_target_weights silently
     # ignores the short side).
@@ -485,11 +715,14 @@ def run_simulation(body: Dict[str, Any]) -> Dict[str, Any]:
         "strategy_id": strategy_id, "strategy_params": strat_kwargs,
         "engine_params": cfg_kwargs, "start": start, "end": end,
         "tickers": selected_tickers,
+        # Edited source goes into the cache key so two runs with different
+        # edits don't collide. Use a hash so we don't bloat the key.
+        "src_hash": hashlib.md5(source_override.encode()).hexdigest() if source_override else None,
     })
     if key in _SIM_CACHE:
         return _SIM_CACHE[key]
 
-    window = (pd.Timestamp(start), pd.Timestamp(end))
+    window = (start_ts, end_ts)
 
     prices = dataset.prices.loc[window[0]:window[1]]
     if selected_tickers:
@@ -536,11 +769,19 @@ def run_simulation(body: Dict[str, Any]) -> Dict[str, Any]:
     tcost_drag_ann = float(result.transaction_costs.mean() * 252)
 
     response = {
-        "strategy": {"id": strategy_id, "label": strat_entry["label"]},
+        "strategy": {
+            "id": strategy_id,
+            "label": strat_entry["label"],
+            "edited_cls_name": edited_cls_name,
+            "live_edit": bool(source_override),
+        },
         "dates": [d.strftime("%Y-%m-%d") for d in result.net_returns.index],
         "cumulative_net": [float(v) for v in net_cum.values],
         "cumulative_benchmark": [float(v) for v in bench_cum.values],
-        "metrics_net": _metrics(result.net_returns),
+        "metrics_net": _metrics(
+            result.net_returns,
+            benchmark=benchmark.reindex(result.net_returns.index).fillna(0),
+        ),
         "metrics_benchmark": _metrics(benchmark.reindex(result.net_returns.index).fillna(0)),
         "order_summary": {
             "turnover_annualized": turnover_ann,
@@ -567,8 +808,10 @@ def run_simulation(body: Dict[str, Any]) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 # Data inspector
 # ---------------------------------------------------------------------------
-def data_overview() -> Dict[str, Any]:
+def data_overview(source: str = None) -> Dict[str, Any]:
     """Per-ticker summary rows for the table view."""
+    if source:
+        ensure_ready(source)
     if not _STATE["ready"]:
         raise RuntimeError("simulator not ready")
     dataset = _STATE["dataset"]
@@ -616,8 +859,10 @@ def data_overview() -> Dict[str, Any]:
     }
 
 
-def ticker_detail(ticker: str) -> Dict[str, Any]:
+def ticker_detail(ticker: str, source: str = None) -> Dict[str, Any]:
     """Price history + summary stats for a single ticker."""
+    if source:
+        ensure_ready(source)
     if not _STATE["ready"]:
         raise RuntimeError("simulator not ready")
     dataset = _STATE["dataset"]

--- a/simulation/frontend/app.ts
+++ b/simulation/frontend/app.ts
@@ -33,6 +33,7 @@ interface Strategy {
   source_file: string;
   source: string;
   summary: string;
+  formula?: string;
   params: ParamSpec[];
   engine_overrides?: ParamSpec[];
 }
@@ -48,7 +49,15 @@ interface Catalog {
 interface Metrics {
   sharpe?: number | null;
   annualized_return?: number | null;
+  annualized_volatility?: number | null;
   max_drawdown?: number | null;
+  win_rate?: number | null;
+  hit_rate?: number | null;
+  sortino?: number | null;
+  calmar?: number | null;
+  profit_factor?: number | null;
+  info_ratio?: number | null;
+  beta?: number | null;
 }
 
 interface OrderSummary {
@@ -160,6 +169,7 @@ interface AppState {
   universeSize: number;
   fullUniverseSize: number;
   customTickers: string[];
+  universeMissingCount: number;
   // True when the user has explicitly narrowed the universe. Lets us
   // distinguish "empty filter = user deliberately picked 0 tickers" from
   // "empty filter = default full cache", which used to get conflated and
@@ -168,6 +178,11 @@ interface AppState {
   pinnedRuns: PinnedRun[];
   dataSource: string;
   availableSources: string[];
+  // Live code editor: per-strategy edited source, keyed by strategy id.
+  // null means "no edit active" — the catalog source is rendered.
+  editedSourceByStrategy: Record<string, string>;
+  // Whether the editor pane is currently visible (textarea up, pre hidden).
+  editing: boolean;
 }
 
 interface SimRequest {
@@ -178,6 +193,7 @@ interface SimRequest {
   tickers: string[] | null;
   start: string;
   end: string;
+  data_source?: string;
 }
 
 interface PinnedRun {
@@ -231,10 +247,13 @@ type StatusKind = "ready" | "loading" | "error" | "" | undefined;
     universeSize: 0,
     fullUniverseSize: 0,
     customTickers: [],
+    universeMissingCount: 0,
     hasCustomFilter: false,
     pinnedRuns: loadPinnedFromStorage(),
     dataSource: "yfinance",
     availableSources: ["yfinance", "wharton"],
+    editedSourceByStrategy: {},
+    editing: false,
   };
 
   function loadPinnedFromStorage(): PinnedRun[] {
@@ -367,12 +386,40 @@ type StatusKind = "ready" | "loading" | "error" | "" | undefined;
     el.textContent = text;
     el.className = "statusbar" + (kind ? ` ${kind}` : "");
   }
+  function assertValidDateRange(start: string, end: string): void {
+    if (start && end && start > end) {
+      throw new Error(`start date must be on or before end date (${start} > ${end})`);
+    }
+  }
+  const sleep = (ms: number): Promise<void> =>
+    new Promise((resolve) => window.setTimeout(resolve, ms));
+  async function fetchJson<T>(url: string, init?: RequestInit, retries = 2): Promise<T> {
+    let lastErr: unknown;
+    for (let attempt = 0; attempt <= retries; attempt += 1) {
+      try {
+        const res = await fetch(url, init);
+        if (!res.ok) {
+          const err = (await res.json().catch(() => ({ error: `HTTP ${res.status}` }))) as {
+            error?: string;
+          };
+          throw new Error(err.error || `HTTP ${res.status}`);
+        }
+        return (await res.json()) as T;
+      } catch (exc) {
+        lastErr = exc;
+        if (attempt === retries) break;
+        await sleep(350 * (attempt + 1));
+      }
+    }
+    throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+  }
+  function sourceQuery(src = state.dataSource): string {
+    return `source=${encodeURIComponent(src)}`;
+  }
 
   // ---------- Catalog & tabs ----------
   async function loadCatalog(): Promise<Catalog> {
-    const res = await fetch("/api/catalog");
-    if (!res.ok) throw new Error(`catalog HTTP ${res.status}`);
-    return (await res.json()) as Catalog;
+    return fetchJson<Catalog>("/api/catalog");
   }
   function renderStrategyTabs(): void {
     const nav = $("strategy-tabs");
@@ -389,14 +436,34 @@ type StatusKind = "ready" | "loading" | "error" | "" | undefined;
       nav.appendChild(btn);
     });
   }
+  function renderStrategyHeader(s: Strategy): void {
+    const host = $("strategy-summary");
+    const formula = (s.formula || "").trim();
+    const summary = (s.summary || "").trim();
+    if (!formula && !summary) {
+      host.textContent = "";
+      return;
+    }
+    const formulaHtml = formula
+      ? `<span class="formula">${escapeHtml(formula)}</span>`
+      : "";
+    const captionHtml = summary
+      ? `<span class="formula-caption">${escapeHtml(summary)}</span>`
+      : "";
+    host.innerHTML = `${formulaHtml}${captionHtml}`;
+  }
+
   function selectStrategy(id: string): void {
     const s = state.catalog!.strategies.find((x) => x.id === id);
     if (!s) return;
     state.currentStrategy = s;
+    // Switching tabs always exits editor mode — but per-strategy edits are
+    // preserved in editedSourceByStrategy and re-applied on return.
+    state.editing = false;
     document.querySelectorAll<HTMLButtonElement>("#strategy-tabs button").forEach((b) => {
       b.classList.toggle("active", b.dataset.id === id);
     });
-    $("strategy-summary").textContent = s.summary;
+    renderStrategyHeader(s);
     renderStrategyParams();
     renderOverrideParams();
     renderEngineParams();
@@ -636,9 +703,10 @@ ${liveCfgLines}
 ${fixedLines}
 )`;
 
+    const classSource = state.editedSourceByStrategy[s.id] ?? s.source;
     const full =
 `# ── class source — ${s.source_file}
-${s.source}
+${classSource}
 
 # ── your run (live values below)
 ${stratCall}
@@ -653,8 +721,103 @@ result  = run_weight_backtest(dataset.prices, weights, config,
     const el = $("code-live");
     el.textContent = full;
     Prism.highlightElement(el);
+    syncEditButtons();
     updateSizing();
   }
+
+  // ---------- Live code editor ----------
+  function syncEditButtons(): void {
+    const s = state.currentStrategy;
+    const hasEdit = !!(s && state.editedSourceByStrategy[s.id] != null);
+    const status = $("code-edit-status");
+    const toggleBtn = $("code-edit-toggle") as HTMLButtonElement;
+    const runBtn = $("code-edit-run") as HTMLButtonElement;
+    const revertBtn = $("code-edit-revert") as HTMLButtonElement;
+    const editor = $("code-editor") as HTMLTextAreaElement;
+    const pre = document.querySelector(".code-block") as HTMLElement | null;
+
+    if (state.editing) {
+      toggleBtn.textContent = "Cancel";
+      runBtn.hidden = false;
+      revertBtn.hidden = !hasEdit;
+      editor.hidden = false;
+      if (pre) pre.hidden = true;
+      status.textContent = "editing — Cmd+Enter to run";
+    } else {
+      toggleBtn.textContent = hasEdit ? "Edit (modified)" : "Edit";
+      runBtn.hidden = true;
+      revertBtn.hidden = !hasEdit;
+      editor.hidden = true;
+      if (pre) pre.hidden = false;
+      status.textContent = hasEdit ? "running edited code" : "";
+    }
+  }
+  function classSourceForCurrent(): string {
+    const s = state.currentStrategy!;
+    return state.editedSourceByStrategy[s.id] ?? s.source;
+  }
+  function enterEditMode(): void {
+    const s = state.currentStrategy;
+    if (!s) return;
+    const editor = $("code-editor") as HTMLTextAreaElement;
+    editor.value = classSourceForCurrent();
+    state.editing = true;
+    syncEditButtons();
+    editor.focus();
+  }
+  function exitEditMode(): void {
+    state.editing = false;
+    syncEditButtons();
+  }
+  function runEditedCode(): void {
+    const s = state.currentStrategy;
+    if (!s) return;
+    const editor = $("code-editor") as HTMLTextAreaElement;
+    const src = editor.value;
+    if (!src.trim()) {
+      toast("editor is empty — nothing to run", true);
+      return;
+    }
+    state.editedSourceByStrategy[s.id] = src;
+    state.editing = false;
+    renderLiveCode();
+    scheduleRun();
+  }
+  function revertEdit(): void {
+    const s = state.currentStrategy;
+    if (!s) return;
+    delete state.editedSourceByStrategy[s.id];
+    state.editing = false;
+    renderLiveCode();
+    scheduleRun();
+  }
+  ($("code-edit-toggle") as HTMLButtonElement).addEventListener("click", () => {
+    if (state.editing) exitEditMode();
+    else enterEditMode();
+  });
+  ($("code-edit-run") as HTMLButtonElement).addEventListener("click", runEditedCode);
+  ($("code-edit-revert") as HTMLButtonElement).addEventListener("click", revertEdit);
+  ($("code-editor") as HTMLTextAreaElement).addEventListener("keydown", (ev) => {
+    if ((ev.metaKey || ev.ctrlKey) && ev.key === "Enter") {
+      ev.preventDefault();
+      runEditedCode();
+      return;
+    }
+    if (ev.key === "Escape") {
+      ev.preventDefault();
+      exitEditMode();
+      return;
+    }
+    // Tab inserts indent rather than moving focus.
+    if (ev.key === "Tab") {
+      ev.preventDefault();
+      const ta = ev.currentTarget as HTMLTextAreaElement;
+      const s = ta.selectionStart;
+      const e = ta.selectionEnd;
+      ta.value = ta.value.slice(0, s) + "    " + ta.value.slice(e);
+      ta.selectionStart = ta.selectionEnd = s + 4;
+    }
+  });
 
   // ---------- Run ----------
   let runTimer: number | null = null;
@@ -682,35 +845,33 @@ result  = run_weight_backtest(dataset.prices, weights, config,
     setStatus("running simulation…", "loading");
     try {
       const p = readParams();
+      assertValidDateRange(p.start, p.end);
       // Send tickers:null only when NO custom filter is active. An empty
       // array with hasCustomFilter=true means "user explicitly narrowed
       // to nothing" and should bubble up as a backend error, not silently
       // flip back to the full universe.
       const tickers = state.hasCustomFilter ? p.tickers : null;
-      const body = {
-        strategy_id: state.currentStrategy!.id,
+      const sid = state.currentStrategy!.id;
+      const editedSrc = state.editedSourceByStrategy[sid];
+      const body: Record<string, unknown> = {
+        strategy_id: sid,
         strategy_params: p.strategyParams,
         engine_params: p.engineParams,
         engine_overrides: p.engineOverrides,
         tickers,
         start: p.start,
         end: p.end,
+        data_source: state.dataSource,
       };
+      if (editedSrc != null) body.strategy_source_override = editedSrc;
       const t0 = performance.now();
-      const res = await fetch("/api/simulate", {
+      const data = await fetchJson<SimulationResult>("/api/simulate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
-      });
-      if (!res.ok) {
-        const err = (await res.json().catch(() => ({ error: `HTTP ${res.status}` }))) as {
-          error?: string;
-        };
-        throw new Error(err.error || `HTTP ${res.status}`);
-      }
-      const data = (await res.json()) as SimulationResult;
+      }, 1);
       const elapsed = performance.now() - t0;
-      lastRender.simPayload = body;
+      lastRender.simPayload = body as unknown as SimRequest;
       renderResults(data);
       setStatus(`ready · last run ${(elapsed / 1000).toFixed(2)}s`, "ready");
     } catch (exc) {
@@ -770,6 +931,35 @@ result  = run_weight_backtest(dataset.prices, weights, config,
       fmtPct(o.tcost_drag_annualized),
       "bad",
       `turnover ${fmtX(o.turnover_annualized, 1)}/yr`,
+    );
+    // Secondary row — Sortino, Calmar, Info Ratio, Hit Rate
+    setCard(
+      "m-sortino",
+      "m-sortino-sub",
+      fmtNum(m.sortino),
+      (m.sortino ?? 0) >= 1 ? "good" : ((m.sortino as number) < 0.3 ? "bad" : ""),
+      `downside-only Sharpe`,
+    );
+    setCard(
+      "m-calmar",
+      "m-calmar-sub",
+      fmtNum(m.calmar),
+      (m.calmar ?? 0) >= 0.5 ? "good" : ((m.calmar as number) < 0 ? "bad" : ""),
+      `ann ret / |max DD|`,
+    );
+    setCard(
+      "m-ir",
+      "m-ir-sub",
+      fmtNum(m.info_ratio),
+      (m.info_ratio ?? 0) >= 0.5 ? "good" : ((m.info_ratio as number) < 0 ? "bad" : ""),
+      `vs benchmark`,
+    );
+    setCard(
+      "m-hit",
+      "m-hit-sub",
+      fmtPct(m.hit_rate, 1),
+      (m.hit_rate ?? 0) >= 0.52 ? "good" : ((m.hit_rate as number) < 0.48 ? "bad" : ""),
+      `pos days / total`,
     );
 
     lastRender.sim = data;
@@ -835,6 +1025,15 @@ result  = run_weight_backtest(dataset.prices, weights, config,
     renderPinnedList();
     if (data.universe && typeof data.universe.n_tickers === "number") {
       state.universeSize = data.universe.n_tickers;
+      state.universeMissingCount = data.universe.missing_from_cache?.length || 0;
+      if (data.universe.custom) {
+        state.hasCustomFilter = true;
+        state.customTickers = (data.universe.selected || []).slice();
+      } else {
+        state.hasCustomFilter = false;
+        state.customTickers = [];
+      }
+      refreshUniverseStatus();
       updateSizing();
     }
   }
@@ -877,6 +1076,7 @@ result  = run_weight_backtest(dataset.prices, weights, config,
       JSON.stringify(p.engine_overrides),
       p.start,
       p.end,
+      p.data_source || "yfinance",
       tickerHash,
     ].join("|");
   }
@@ -1028,11 +1228,9 @@ result  = run_weight_backtest(dataset.prices, weights, config,
   function renderAudit(a: SurvivorshipAudit): void {
     const sub = $("audit-sub");
     const statsEl = $("audit-stats");
-    const noteEl = $("audit-note");
     if (!a || !a.universe_size) {
       sub.textContent = "no audit available";
       statsEl.innerHTML = "";
-      noteEl.textContent = "";
       Plotly.purge("chart-audit");
       return;
     }
@@ -1054,7 +1252,6 @@ result  = run_weight_backtest(dataset.prices, weights, config,
       <div class="a-cell"><div class="a-label">Post-start inceptions</div><div class="a-value ${inceptionCls}">${a.inception_biased_count}</div></div>
       <div class="a-cell"><div class="a-label">Delistings in window</div><div class="a-value ${delistCls}">${a.delisted_within_window_count}</div></div>
     `;
-    noteEl.textContent = a.structural_bias_note || "";
 
     const ts: AuditTimeseries = a.active_timeseries || { dates: [], counts: [] };
     const auPal = chartPalette();
@@ -1096,15 +1293,14 @@ result  = run_weight_backtest(dataset.prices, weights, config,
 
   // ---------- Data inspector ----------
   async function loadDataOverview(): Promise<void> {
-    const res = await fetch("/api/data");
-    if (!res.ok) throw new Error(`data HTTP ${res.status}`);
-    state.dataOverview = (await res.json()) as DataOverview;
+    state.dataOverview = await fetchJson<DataOverview>(`/api/data?${sourceQuery()}`);
     $("data-sub").textContent = `${state.dataOverview.n_tickers} tickers · ${state.dataOverview.source_file}`;
     renderTickerTable();
   }
   function renderTickerTable(): void {
     const body = $("ticker-tbody");
     body.innerHTML = "";
+    if (!state.dataOverview) return;
     const q = state.tickerFilter.toLowerCase();
     const rows = state.dataOverview!.tickers.filter(
       (r) =>
@@ -1151,9 +1347,9 @@ result  = run_weight_backtest(dataset.prices, weights, config,
     const right = $("data-right");
     right.innerHTML = `<div class="data-empty">Loading ${tic}…</div>`;
     try {
-      const res = await fetch(`/api/data/ticker/${encodeURIComponent(tic)}`);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const d = (await res.json()) as TickerDetail;
+      const d = await fetchJson<TickerDetail>(
+        `/api/data/ticker/${encodeURIComponent(tic)}?${sourceQuery()}`,
+      );
       renderTickerDetail(d);
     } catch (exc) {
       const msg = exc instanceof Error ? exc.message : String(exc);
@@ -1254,7 +1450,10 @@ result  = run_weight_backtest(dataset.prices, weights, config,
       status.textContent = `all cached (${state.fullUniverseSize || "?"})`;
     } else {
       const n = state.customTickers.length;
-      status.textContent = `custom: ${n} ticker${n === 1 ? "" : "s"}`;
+      const missing = state.universeMissingCount
+        ? ` · ${state.universeMissingCount} ignored`
+        : "";
+      status.textContent = `custom: ${n} ticker${n === 1 ? "" : "s"}${missing}`;
     }
   }
   const universeInput = document.getElementById("universe-input") as HTMLTextAreaElement | null;
@@ -1270,6 +1469,7 @@ result  = run_weight_backtest(dataset.prices, weights, config,
       }
       state.customTickers = tickers;
       state.hasCustomFilter = true;
+      state.universeMissingCount = 0;
       refreshUniverseStatus();
       updateSizing();
       scheduleRun();
@@ -1280,6 +1480,7 @@ result  = run_weight_backtest(dataset.prices, weights, config,
       universeInput.value = "";
       state.customTickers = [];
       state.hasCustomFilter = false;
+      state.universeMissingCount = 0;
       refreshUniverseStatus();
       updateSizing();
       scheduleRun();
@@ -1311,6 +1512,7 @@ result  = run_weight_backtest(dataset.prices, weights, config,
       const missing = excluded.length - matched;
       state.customTickers = complement;
       state.hasCustomFilter = true;
+      state.universeMissingCount = missing;
       const suffix = missing ? ` · ${missing} not in cache (ignored)` : "";
       toast(
         `excluded ${matched} · running on ${complement.length} ticker${complement.length === 1 ? "" : "s"}${suffix}`,
@@ -1371,18 +1573,27 @@ result  = run_weight_backtest(dataset.prices, weights, config,
   }
 
   // ---------- Boot ----------
-  async function waitReady(): Promise<boolean> {
+  async function waitReady(targetSource?: string, maxWaitMs = 0): Promise<boolean> {
+    const started = performance.now();
+    let misses = 0;
     while (true) {
+      if (maxWaitMs && performance.now() - started > maxWaitMs) {
+        const label = targetSource ? sourceLabel(targetSource) : "backend";
+        setStatus(`error: timed out loading ${label}`, "error");
+        return false;
+      }
       try {
-        const res = await fetch("/api/status");
-        const s = (await res.json()) as StatusResponse;
-        if (s.error) {
+        const url = targetSource ? `/api/status?${sourceQuery(targetSource)}` : "/api/status";
+        const s = await fetchJson<StatusResponse>(url, undefined, 0);
+        misses = 0;
+        const sourceMatches = !targetSource || s.data_source === targetSource;
+        if (s.error && sourceMatches) {
           setStatus(`error: ${s.error}`, "error");
           return false;
         }
-        if (s.data_source) state.dataSource = s.data_source;
+        if (s.data_source && sourceMatches) state.dataSource = s.data_source;
         if (s.available_sources) state.availableSources = s.available_sources;
-        if (s.ready) {
+        if (s.ready && sourceMatches) {
           setStatus(`ready · ${s.tickers} tickers · ${s.date_min} → ${s.date_max}`, "ready");
           const startEl = $("start") as HTMLInputElement;
           const endEl = $("end") as HTMLInputElement;
@@ -1399,12 +1610,16 @@ result  = run_weight_backtest(dataset.prices, weights, config,
           updateUniverseEditorMode();
           return true;
         }
-        setStatus(`loading · ${s.message}`, "loading");
+        if (s.ready && targetSource) {
+          setStatus(`loading · waiting for ${sourceLabel(targetSource)}`, "loading");
+        } else {
+          setStatus(`loading · ${s.message || "dataset"}`, "loading");
+        }
       } catch (exc) {
-        setStatus("backend unreachable", "error");
-        return false;
+        misses += 1;
+        setStatus(`backend unreachable · retrying (${misses})`, misses > 5 ? "error" : "loading");
       }
-      await new Promise((r) => setTimeout(r, 1000));
+      await sleep(Math.min(1000 + misses * 250, 2500));
     }
   }
 
@@ -1443,19 +1658,68 @@ result  = run_weight_backtest(dataset.prices, weights, config,
       fetchBtn.disabled = false;
     }
   }
+  function setSourceSelectorBusy(busy: boolean): void {
+    const sel = document.getElementById("source-select") as HTMLSelectElement | null;
+    if (sel) sel.disabled = busy;
+  }
+  function showSourceLoadingState(target: string): void {
+    const label = sourceLabel(target);
+    $("universe-label").textContent = `universe: loading ${label}`;
+    $("universe-status").textContent = "loading…";
+    $("strategy-sizing").textContent = "loading universe…";
+    $("data-sub").textContent = `loading ${label} data…`;
+    for (const [valueId, subId] of [
+      ["m-sharpe", "m-sharpe-sub"],
+      ["m-return", "m-return-sub"],
+      ["m-dd", "m-dd-sub"],
+      ["m-tcost", "m-tcost-sub"],
+      ["m-sortino", "m-sortino-sub"],
+      ["m-calmar", "m-calmar-sub"],
+      ["m-ir", "m-ir-sub"],
+      ["m-hit", "m-hit-sub"],
+    ]) {
+      const valueEl = $(valueId);
+      valueEl.textContent = "—";
+      valueEl.className = "m-value";
+      $(subId).textContent = "";
+    }
+    $("audit-sub").textContent = `loading ${label} universe`;
+    $("audit-stats").innerHTML = "";
+    Plotly.purge("chart-equity");
+    Plotly.purge("chart-audit");
+    state.dataOverview = null;
+    state.selectedTicker = null;
+    renderTickerTable();
+    const right = document.getElementById("data-right");
+    if (right) {
+      right.innerHTML = `<div class="data-empty">Loading ${escapeHtml(label)} data…</div>`;
+    }
+  }
   async function switchDataSource(target: string): Promise<void> {
     if (target === state.dataSource) return;
+    const previousSource = state.dataSource;
     state.dataSource = target;
+    updateSourceSelector();
+    updateUniverseEditorMode();
+    setSourceSelectorBusy(true);
+    showSourceLoadingState(target);
     setStatus(`switching to ${sourceLabel(target)}…`, "loading");
     setProgress(15);
     try {
-      const res = await fetch("/api/warmup", {
+      await fetchJson<StatusResponse>("/api/warmup", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ source: target }),
-      });
-      if (!res.ok) {
-        throw new Error(`HTTP ${res.status}`);
+      }, 1);
+      // Now wait for a worker that is actually ready on the requested
+      // source. Production can have more than one backend worker, so a
+      // generic "ready" status is not enough after a source change.
+      const ok = await waitReady(target, 120000);
+      if (!ok) {
+        state.dataSource = previousSource;
+        updateSourceSelector();
+        updateUniverseEditorMode();
+        return;
       }
       // Clear pinned runs — their tickers / dates may not exist in the
       // new universe, and the chart palette is shared. Toast so the user
@@ -1467,10 +1731,6 @@ result  = run_weight_backtest(dataset.prices, weights, config,
         renderPinnedList();
         toast(`cleared ${n} pinned run${n === 1 ? "" : "s"} — new data source`, false, 4000);
       }
-      // Now wait for the backend to finish reloading. Reuse waitReady's
-      // polling logic so the rest of the boot flow stays consistent.
-      const ok = await waitReady();
-      if (!ok) return;
       state.catalog = await loadCatalog();
       const stillSelectable = state.currentStrategy
         ? state.catalog.strategies.find((s) => s.id === state.currentStrategy!.id)
@@ -1492,9 +1752,13 @@ result  = run_weight_backtest(dataset.prices, weights, config,
       loadDataOverview().catch((e) => console.error(e));
     } catch (exc) {
       const msg = exc instanceof Error ? exc.message : String(exc);
+      state.dataSource = previousSource;
+      updateSourceSelector();
+      updateUniverseEditorMode();
       toast(`source switch failed: ${msg}`, true, 6000);
       setStatus(`error: ${msg}`, "error");
     } finally {
+      setSourceSelectorBusy(false);
       progressDone();
     }
   }
@@ -1509,10 +1773,16 @@ result  = run_weight_backtest(dataset.prices, weights, config,
   (async (): Promise<void> => {
     setStatus("connecting…", "loading");
     renderPinnedList();
-    if (!(await waitReady())) return;
-    state.catalog = await loadCatalog();
-    renderStrategyTabs();
-    selectStrategy(state.catalog.strategies[0].id);
-    loadDataOverview().catch((e) => console.error(e));
+    try {
+      if (!(await waitReady())) return;
+      state.catalog = await loadCatalog();
+      renderStrategyTabs();
+      selectStrategy(state.catalog.strategies[0].id);
+      loadDataOverview().catch((e) => console.error(e));
+    } catch (exc) {
+      const msg = exc instanceof Error ? exc.message : String(exc);
+      toast(`startup failed: ${msg}`, true, 6000);
+      setStatus(`error: ${msg}`, "error");
+    }
   })();
 })();

--- a/simulation/frontend/app.ts
+++ b/simulation/frontend/app.ts
@@ -103,6 +103,12 @@ interface RunConfig {
   leverage: number;
 }
 
+interface MonthlyReturn {
+  year: number;
+  month: number;
+  ret: number;
+}
+
 interface SimulationResult {
   metrics_net?: Metrics;
   metrics_benchmark?: Metrics;
@@ -110,6 +116,9 @@ interface SimulationResult {
   dates: string[];
   cumulative_benchmark: number[];
   cumulative_net: number[];
+  cumulative_drawdown?: number[];
+  cumulative_drawdown_benchmark?: number[];
+  monthly_returns?: MonthlyReturn[];
   survivorship_audit?: SurvivorshipAudit;
   universe?: UniverseSummary;
   config?: RunConfig;
@@ -202,8 +211,9 @@ interface PinnedRun {
   strategyLabel: string;  // for display in chip subtext
   colorIdx: number;       // index into series-color rotation
   dates: string[];
-  cumulativeNet: number[]; // already in percent (× 100), like the live trace
-  payload: SimRequest;     // snapshot of the request that produced this curve
+  cumulativeNet: number[];      // already in percent (× 100), like the live trace
+  cumulativeDrawdown?: number[]; // fraction underwater, percent (× 100)
+  payload: SimRequest;          // snapshot of the request that produced this curve
   metricsNet?: Metrics;
 }
 
@@ -681,9 +691,14 @@ type StatusKind = "ready" | "loading" | "error" | "" | undefined;
     const stratArgs = Object.entries(strategyParams)
       .map(([k, v]) => `    ${k}=${pyRepr(v)},`)
       .join("\n");
+    // If the user edited the class source, parse the new class name so the
+    // "your run" snippet reflects what actually executes.
+    const editedSrc = state.editedSourceByStrategy[s.id];
+    const editedClsMatch = editedSrc ? editedSrc.match(/class\s+(\w+)\s*\(/) : null;
+    const clsName = editedClsMatch ? editedClsMatch[1] : s.cls_name;
     const stratCall = stratArgs
-      ? `strategy = ${s.cls_name}(\n${stratArgs}\n)`
-      : `strategy = ${s.cls_name}()`;
+      ? `strategy = ${clsName}(\n${stratArgs}\n)`
+      : `strategy = ${clsName}()`;
 
     // Merge: live knobs + per-strategy overrides win; fixed defaults fill in.
     const fixedEngine: Record<string, unknown> = { ...state.catalog!.fixed_engine };

--- a/simulation/frontend/index.html
+++ b/simulation/frontend/index.html
@@ -79,8 +79,15 @@
           <header class="panel-head">
             <h3>Live code</h3>
             <span class="panel-sub" id="code-path">strategies/research_strategies.py + backtester/research_backtester.py</span>
+            <div class="code-edit-toolbar">
+              <span class="code-edit-status" id="code-edit-status"></span>
+              <button type="button" id="code-edit-toggle" class="code-edit-btn">Edit</button>
+              <button type="button" id="code-edit-run" class="code-edit-btn primary" hidden>Run edited</button>
+              <button type="button" id="code-edit-revert" class="code-edit-btn" hidden>Revert</button>
+            </div>
           </header>
           <pre class="code-block"><code id="code-live" class="language-python"></code></pre>
+          <textarea id="code-editor" class="code-editor" hidden spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off"></textarea>
         </div>
 
         <div class="metrics-strip">
@@ -88,6 +95,10 @@
           <div class="m-card"><div class="m-label">Ann. return</div><div class="m-value" id="m-return">—</div><div class="m-sub" id="m-return-sub"></div></div>
           <div class="m-card"><div class="m-label">Max drawdown</div><div class="m-value" id="m-dd">—</div><div class="m-sub" id="m-dd-sub"></div></div>
           <div class="m-card"><div class="m-label">T-cost drag / yr</div><div class="m-value" id="m-tcost">—</div><div class="m-sub" id="m-tcost-sub"></div></div>
+          <div class="m-card secondary"><div class="m-label">Sortino</div><div class="m-value" id="m-sortino">—</div><div class="m-sub" id="m-sortino-sub"></div></div>
+          <div class="m-card secondary"><div class="m-label">Calmar</div><div class="m-value" id="m-calmar">—</div><div class="m-sub" id="m-calmar-sub"></div></div>
+          <div class="m-card secondary"><div class="m-label">Info ratio</div><div class="m-value" id="m-ir">—</div><div class="m-sub" id="m-ir-sub"></div></div>
+          <div class="m-card secondary"><div class="m-label">Hit rate</div><div class="m-value" id="m-hit">—</div><div class="m-sub" id="m-hit-sub"></div></div>
         </div>
 
         <div class="panel">
@@ -120,7 +131,6 @@
           <div class="audit-body">
             <div class="audit-stats" id="audit-stats"></div>
             <div id="chart-audit" class="audit-chart"></div>
-            <p class="audit-note" id="audit-note"></p>
           </div>
         </div>
 
@@ -134,6 +144,14 @@
               <input id="ticker-search" class="search" placeholder="Filter tickers…" />
               <div class="table-wrap">
                 <table class="ticker-table" id="ticker-table">
+                  <colgroup>
+                    <col class="col-ticker" />
+                    <col class="col-name" />
+                    <col class="col-sector" />
+                    <col class="col-start" />
+                    <col class="col-end" />
+                    <col class="col-ret" />
+                  </colgroup>
                   <thead>
                     <tr>
                       <th>Ticker</th><th>Name</th><th>Sector</th>

--- a/simulation/frontend/style.css
+++ b/simulation/frontend/style.css
@@ -1170,9 +1170,9 @@ a:hover { color: var(--amber-hot); text-decoration: underline; }
   .app-split { grid-template-columns: 1fr; }
   .sidebar { position: static; max-height: none; overflow: visible; }
   .metrics-strip { grid-template-columns: repeat(2, 1fr); }
-  .metrics-strip .m-card { border-bottom: 1px solid var(--border); }
-  .metrics-strip .m-card:nth-child(2n) { border-right: 0; }
-  .metrics-strip .m-card:nth-last-child(-n+2) { border-bottom: 0; }
+  .metrics-strip .m-card { border-bottom: 1px solid var(--border) !important; border-right: 1px solid var(--border) !important; }
+  .metrics-strip .m-card:nth-child(2n) { border-right: 0 !important; }
+  .metrics-strip .m-card:nth-last-child(-n+2) { border-bottom: 0 !important; }
   .data-body { grid-template-columns: 1fr; }
   .data-left { border-right: 0; border-bottom: 1px solid var(--border); }
   .statusbar::after { display: none; }

--- a/simulation/frontend/style.css
+++ b/simulation/frontend/style.css
@@ -174,27 +174,33 @@ a:hover { color: var(--amber-hot); text-decoration: underline; }
 
 /* Strategy tabs — segmented, selected state is filled amber */
 .strategy-tabs {
-  display: inline-flex;
+  display: flex;
   align-items: stretch;
   border: 1px solid var(--border);
   background: var(--bg);
   height: 34px;
   justify-self: center;
+  max-width: 100%;
+  overflow-x: auto;
+  scrollbar-width: none;          /* Firefox */
 }
+.strategy-tabs::-webkit-scrollbar { display: none; }
 .strategy-tabs button {
   background: transparent;
   border: 0;
   border-right: 1px solid var(--border);
-  padding: 0 18px;
+  padding: 0 14px;
   height: 100%;
   font-family: var(--font-mono);
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--text-2);
   cursor: pointer;
   transition: color 0.08s, background 0.08s;
+  white-space: nowrap;
+  flex: 0 0 auto;
 }
 .strategy-tabs button:last-child { border-right: 0; }
 .strategy-tabs button:hover { color: var(--amber-hot); background: var(--panel-2); }
@@ -349,8 +355,33 @@ a:hover { color: var(--amber-hot); text-decoration: underline; }
   margin-bottom: 5px;
 }
 .strategy-summary:empty,
-.strategy-sizing:empty,
-.audit-note:empty { display: none; }
+.strategy-sizing:empty { display: none; }
+
+/* Strategy formula — math expression rendered in mono+amber with phosphor glow,
+   then a muted plain-English caption beneath it. */
+.strategy-summary .formula {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 14.5px;
+  line-height: 1.45;
+  letter-spacing: 0.01em;
+  color: var(--amber);
+  text-shadow: 0 0 8px var(--amber-glow);
+  padding: 6px 0 8px;
+  border-top: 1px solid var(--border);
+  margin-top: 4px;
+  font-feature-settings: "ss01", "zero";
+  word-break: keep-all;
+}
+.strategy-summary .formula-caption {
+  display: block;
+  font-family: var(--font-sans);
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--text-3);
+  margin-top: 2px;
+  font-style: italic;
+}
 
 .strategy-sizing {
   margin: 0;
@@ -574,6 +605,62 @@ a:hover { color: var(--amber-hot); text-decoration: underline; }
 
 /* ---- Code panel ---- */
 .code-panel { min-height: 280px; }
+.code-edit-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+.code-edit-status {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--accent);
+  min-width: 0;
+  white-space: nowrap;
+}
+.code-edit-btn {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  background: transparent;
+  color: var(--text-2);
+  border: 1px solid var(--border);
+  padding: 4px 10px;
+  cursor: pointer;
+  border-radius: 2px;
+}
+.code-edit-btn:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.code-edit-btn.primary {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+.code-edit-btn.primary:hover {
+  background: rgba(var(--accent-rgb, 255, 176, 0), 0.08);
+}
+.code-edit-btn[disabled] { opacity: 0.4; cursor: not-allowed; }
+.code-editor {
+  flex: 1 1 auto;
+  width: 100%;
+  min-height: 320px;
+  max-height: 380px;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  background: var(--bg);
+  color: var(--text);
+  border: 0;
+  outline: 0;
+  padding: 14px 16px;
+  line-height: 1.6;
+  tab-size: 4;
+  resize: vertical;
+  white-space: pre;
+  overflow: auto;
+}
+.code-editor:focus { outline: 0; box-shadow: inset 0 0 0 1px var(--accent); }
 .code-block {
   margin: 0;
   flex: 1 1 auto;
@@ -625,10 +712,11 @@ a:hover { color: var(--amber-hot); text-decoration: underline; }
 .code-block .token.variable { color: var(--warn); }
 .code-block .token.operator { color: var(--text-2); background: transparent; }
 
-/* ---- Metrics strip — hero numbers with phosphor glow ---- */
+/* ---- Metrics strip — 4×2 grid: hero row glows big, secondary row tighter ---- */
 .metrics-strip {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
+  grid-auto-rows: auto;
   gap: 0;
   background: var(--panel);
   border: 1px solid var(--border);
@@ -636,7 +724,14 @@ a:hover { color: var(--amber-hot); text-decoration: underline; }
 .m-card {
   padding: 18px 22px;
   border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
   position: relative;
+}
+.m-card:nth-child(4n) { border-right: 0; }
+.m-card:nth-last-child(-n+4) { border-bottom: 0; }
+.m-card.secondary {
+  padding: 12px 22px 14px;
+  background: var(--panel-2);
 }
 .m-card::before {
   content: "";
@@ -656,6 +751,11 @@ a:hover { color: var(--amber-hot); text-decoration: underline; }
   color: var(--text-3);
   margin-bottom: 8px;
 }
+.m-card.secondary .m-label {
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  margin-bottom: 4px;
+}
 .m-value {
   font-family: var(--font-mono);
   font-size: 44px;
@@ -666,8 +766,14 @@ a:hover { color: var(--amber-hot); text-decoration: underline; }
   letter-spacing: -0.02em;
   text-shadow: 0 0 16px var(--amber-glow);
 }
+.m-card.secondary .m-value {
+  font-size: 26px;
+  text-shadow: 0 0 10px var(--amber-glow);
+}
 .m-value.good { color: var(--gain); text-shadow: 0 0 16px rgba(105,201,122,0.5); }
 .m-value.bad  { color: var(--loss); text-shadow: 0 0 16px rgba(224,112,80,0.5); }
+.m-card.secondary .m-value.good { text-shadow: 0 0 10px rgba(105,201,122,0.5); }
+.m-card.secondary .m-value.bad  { text-shadow: 0 0 10px rgba(224,112,80,0.5); }
 .m-sub {
   font-family: var(--font-mono);
   font-size: 12px;
@@ -676,6 +782,11 @@ a:hover { color: var(--amber-hot); text-decoration: underline; }
   font-variant-numeric: tabular-nums;
   text-transform: uppercase;
   letter-spacing: 0.08em;
+}
+.m-card.secondary .m-sub {
+  font-size: 10.5px;
+  margin-top: 3px;
+  letter-spacing: 0.06em;
 }
 
 /* ---- Charts ---- */
@@ -836,26 +947,6 @@ a:hover { color: var(--amber-hot); text-decoration: underline; }
 .audit-stats .a-value.warn { color: var(--warn); }
 .audit-stats .a-value.bad  { color: var(--loss); }
 .audit-chart { min-height: 240px; padding: 10px 12px; }
-.audit-note {
-  grid-column: 1 / -1;
-  margin: 0;
-  padding: 10px 14px;
-  border-top: 1px solid var(--border);
-  background: var(--amber-soft);
-  font-family: var(--font-sans);
-  font-size: 13px;
-  line-height: 1.55;
-  color: var(--text);
-}
-.audit-note::before {
-  content: "▎ NOTE ";
-  font-family: var(--font-mono);
-  font-weight: 600;
-  font-size: 12px;
-  letter-spacing: 0.2em;
-  color: var(--amber);
-  margin-right: 8px;
-}
 @media (max-width: 900px) {
   .audit-body { grid-template-columns: 1fr; }
   .audit-stats { border-right: 0; border-bottom: 1px solid var(--border); }
@@ -870,6 +961,7 @@ a:hover { color: var(--amber-hot); text-decoration: underline; }
 .data-left {
   padding: 12px 14px;
   border-right: 1px solid var(--border);
+  min-width: 0;
 }
 .search {
   width: 100%;
@@ -886,12 +978,14 @@ a:hover { color: var(--amber-hot); text-decoration: underline; }
 .search::placeholder { color: var(--text-mute); }
 .table-wrap {
   max-height: 460px;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
   border: 1px solid var(--border);
   background: var(--bg);
 }
 .ticker-table {
   width: 100%;
+  table-layout: fixed;
   border-collapse: collapse;
   font-family: var(--font-mono);
   font-size: 13px;
@@ -905,17 +999,25 @@ a:hover { color: var(--amber-hot); text-decoration: underline; }
   letter-spacing: 0.18em;
   text-transform: uppercase;
   color: var(--amber);
-  padding: 8px 12px;
+  padding: 8px 10px;
   border-bottom: 1px solid var(--border);
   text-align: left;
   z-index: 1;
+  overflow-wrap: anywhere;
 }
 .ticker-table tbody td {
-  padding: 6px 12px;
+  padding: 6px 10px;
   border-bottom: 1px solid var(--border-soft);
   color: var(--text);
   height: 32px;
+  overflow-wrap: anywhere;
 }
+.ticker-table col.col-ticker { width: 12%; }
+.ticker-table col.col-name   { width: 24%; }
+.ticker-table col.col-sector { width: 20%; }
+.ticker-table col.col-start  { width: 14%; }
+.ticker-table col.col-end    { width: 14%; }
+.ticker-table col.col-ret    { width: 16%; }
 .ticker-table tbody tr {
   cursor: pointer;
   transition: background 0.05s;

--- a/strategies/combined.py
+++ b/strategies/combined.py
@@ -1,0 +1,189 @@
+"""Combined strategy — run several OrderGenerators side-by-side and merge.
+
+Engine quantity semantics (backtester/backtest_engine.py):
+  - float in (0, 1.0]  → fraction of current portfolio value (BUY) or fraction
+                         of current holdings (SELL on long; new short on flat)
+  - everything else    → absolute share count
+
+Combining strategies that all size BUYs as ``q * portfolio_value`` cannot
+just be a concatenation: every child sees the same start-of-day PV, so
+naively merging 4–5 fractional BUYs over-commits cash. ``CombinedOrderGenerator``
+gives each child a weight (default 1/N) and scales orders so the total
+target capital across children stays at ~100% of PV. The one exception is
+``SELL 1.0`` — every child uses that as a "close my entire position"
+sentinel, so it passes through unchanged; scaling it down would leave
+residuals across rebalances. Fractional SELLs below 1.0 *are* scaled
+because the engine reads them as new shorts when a child happens to be
+flat at execution (e.g. PairsTrading's short leg), and an unscaled short
+would blow past the child's allocated capital. Integer share counts
+(CustomerSupplierMomentum's delta-style book) are scaled on both sides
+because they're absolute, not position-relative.
+
+Known cross-talk: the engine maintains one shared book per ticker, so if
+two children both touch the same name (e.g. Momentum buys AAPL while
+Mean Reversion later issues SELL AAPL 1.0), the second child's "close
+all" closes both children's stakes. Run the bundle on a wide enough
+universe that name-level overlap is rare, or curate the children so they
+trade disjoint slices.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence
+
+import pandas as pd
+
+from .order_generator import OrderGenerator
+
+
+class CombinedOrderGenerator(OrderGenerator):
+    """Merge orders from multiple sub-strategies under a per-child capital weight."""
+
+    def __init__(
+        self,
+        generators: Sequence[OrderGenerator],
+        weights: Optional[Sequence[float]] = None,
+        names: Optional[Sequence[str]] = None,
+    ):
+        if not generators:
+            raise ValueError("CombinedOrderGenerator needs at least one sub-strategy")
+        self.generators: List[OrderGenerator] = list(generators)
+
+        n = len(self.generators)
+        if weights is None:
+            weights_list = [1.0 / n] * n
+        else:
+            weights_list = [float(w) for w in weights]
+            if len(weights_list) != n:
+                raise ValueError(
+                    f"weights length ({len(weights_list)}) must match generators length ({n})"
+                )
+            if any(w < 0 for w in weights_list):
+                raise ValueError("weights must be non-negative")
+            total = sum(weights_list)
+            if total <= 0:
+                raise ValueError("weights must sum to a positive value")
+            weights_list = [w / total for w in weights_list]
+        self.weights: List[float] = weights_list
+
+        if names is None:
+            self.names: List[str] = [g.__class__.__name__ for g in self.generators]
+        else:
+            names_list = list(names)
+            if len(names_list) != n:
+                raise ValueError("names length must match generators length")
+            self.names = names_list
+
+    def generate_orders(self, data: pd.DataFrame) -> List[Dict[str, Any]]:
+        all_orders: List[Dict[str, Any]] = []
+        for gen, weight, name in zip(self.generators, self.weights, self.names):
+            sub_orders = gen.generate_orders(data)
+            for order in sub_orders:
+                scaled = self._scale_order(order, weight)
+                if scaled is None:
+                    continue
+                scaled.setdefault("source", name)
+                all_orders.append(scaled)
+
+        all_orders.sort(
+            key=lambda o: (
+                o["date"],
+                o.get("source", ""),
+                o["ticker"],
+                o["type"],
+            )
+        )
+        return all_orders
+
+    @staticmethod
+    def _scale_order(order: Dict[str, Any], weight: float) -> Optional[Dict[str, Any]]:
+        q = order["quantity"]
+        # Treat numpy scalars as their Python counterparts.
+        if hasattr(q, "item"):
+            try:
+                q = q.item()
+            except Exception:
+                pass
+
+        is_fractional = isinstance(q, float) and 0.0 < q <= 1.0
+        # bool is a subclass of int — exclude it so True/False can't sneak in as 1/0 shares.
+        is_integer_shares = isinstance(q, int) and not isinstance(q, bool)
+        # A float >1.0 is malformed for the engine (it doesn't match either branch
+        # cleanly), but scale it as absolute shares to stay close to caller intent.
+        if isinstance(q, float) and q > 1.0:
+            is_integer_shares = True
+
+        side = order["type"]
+        new_q: Any = q
+
+        if side == "BUY":
+            if is_fractional:
+                new_q = float(q) * weight
+            elif is_integer_shares:
+                scaled = int(round(float(q) * weight))
+                if scaled <= 0:
+                    return None
+                new_q = scaled
+        elif side == "SELL":
+            if is_fractional:
+                # SELL 1.0 is the universal "close my entire position" sentinel —
+                # never scale it, otherwise the child can't fully exit. Anything
+                # smaller is either a partial trim or a new short, and both
+                # should be weighted to the child's slice of capital.
+                if float(q) < 1.0:
+                    new_q = float(q) * weight
+            elif is_integer_shares:
+                scaled = int(round(float(q) * weight))
+                if scaled <= 0:
+                    return None
+                new_q = scaled
+
+        out = dict(order)
+        out["quantity"] = new_q
+        return out
+
+
+def build_default_combined(
+    *,
+    pairs: Optional[Sequence[tuple]] = None,
+    capiq_path: Optional[str] = None,
+    capiq_initial_cash: float = 100_000.0,
+    weights: Optional[Sequence[float]] = None,
+) -> CombinedOrderGenerator:
+    """Equal-weight bundle of all five sub-strategies.
+
+    CustomerSupplierMomentum is included only when ``capiq_path`` is provided
+    — it requires a relationship file. Without it, the combined generator
+    falls back to four sub-strategies and weights renormalize to 1/4.
+    """
+    from .customer_supplier_momentum import CustomerSupplierMomentumOrderGenerator
+    from .mean_reversion import MeanReversionOrderGenerator
+    from .momentum_strategy import MomentumOrderGenerator
+    from .moving_avg import MovingAverageOrderGenerator
+    from .pairs_trading import PairsTradingOrderGenerator
+
+    if pairs is None:
+        pairs = [("KO", "PEP"), ("V", "MA")]
+
+    generators: List[OrderGenerator] = [
+        MeanReversionOrderGenerator(window=100, position_size=0.5),
+        MomentumOrderGenerator(window_days=125, threshold=0.02),
+        MovingAverageOrderGenerator(),
+        PairsTradingOrderGenerator(pairs=list(pairs), lookback_window=60),
+    ]
+    names = ["MeanReversion", "Momentum", "MovingAverage", "PairsTrading"]
+
+    if capiq_path:
+        n_other = len(generators)
+        # Pre-scale CustomerSupplier's internal book so its delta-style sizing
+        # already targets its slice of capital — post-hoc scaling of integer
+        # SELL deltas keeps it consistent rebalance-to-rebalance.
+        cs_weight = 1.0 / (n_other + 1)
+        generators.append(
+            CustomerSupplierMomentumOrderGenerator(
+                capiq_path=capiq_path,
+                initial_cash=capiq_initial_cash * cs_weight,
+            )
+        )
+        names.append("CustomerSupplierMomentum")
+
+    return CombinedOrderGenerator(generators=generators, weights=weights, names=names)

--- a/strategies/research_strategies.py
+++ b/strategies/research_strategies.py
@@ -257,6 +257,152 @@ class LowVolatilityStrategy(SignalStrategy):
         return -vol  # higher score = lower vol = more desirable
 
 
+# Curated supplier → customers mapping for the Customer-Supplier Momentum
+# strategy. Without a CapIQ Compustat-Segment file we ship a hand-built
+# subset of well-known supplier/customer pairs that the yfinance S&P 500
+# universe covers out of the box. The strategy averages each customer's
+# recent return into a per-supplier signal — long the suppliers whose
+# customers ran up, short those whose customers lagged.
+CUSTOMER_SUPPLIER_RELATIONSHIPS: dict[str, list[str]] = {
+    # Suppliers feeding NVIDIA's GPU / accelerator stack
+    "TSM":  ["NVDA", "AAPL", "AMD", "QCOM"],
+    "ASML": ["NVDA", "INTC", "AMD", "TSM"],
+    "AMAT": ["NVDA", "TSM", "INTC"],
+    "LRCX": ["NVDA", "TSM", "INTC"],
+    "KLAC": ["NVDA", "TSM", "INTC"],
+    "MU":   ["NVDA", "AAPL", "DELL", "HPQ"],
+    "MRVL": ["NVDA", "META", "GOOGL"],
+    # Apple supply chain
+    "AVGO": ["AAPL", "GOOGL", "META"],
+    "QCOM": ["AAPL", "META", "GOOGL"],
+    "SWKS": ["AAPL"],
+    "QRVO": ["AAPL"],
+    "CRUS": ["AAPL"],
+    # Cloud / hyperscaler accelerators
+    "NVDA": ["MSFT", "META", "GOOGL", "AMZN", "ORCL"],
+    "AMD":  ["MSFT", "META", "GOOGL", "AMZN", "ORCL"],
+    # Logistics
+    "UPS":  ["AMZN", "WMT", "TGT"],
+    "FDX":  ["AMZN", "WMT"],
+    # EV / battery / auto
+    "ALB":  ["TSLA", "GM", "F"],
+    "PCAR": ["AMZN", "UPS", "FDX"],
+    # Industrials / aerospace
+    "HON":  ["BA", "LMT", "RTX"],
+    "TXT":  ["BA", "LMT"],
+    "GE":   ["BA", "LMT"],
+    "PH":   ["BA", "LMT", "CAT"],
+    # Defense supply chain
+    "LDOS": ["LMT", "RTX"],
+}
+
+
+class CustomerSupplierMomentumStrategy(SignalStrategy):
+    name = "Customer-Supplier Momentum"
+    motivation = "Suppliers whose major customers had strong recent stock returns tend to rally next; weak-customer suppliers tend to drift down."
+    economic_rationale = "Cohen & Frazzini (2008): the equity market underreacts to news that originates at a customer firm and only slowly diffuses to its suppliers along the supply chain."
+    why_it_works = "Customer-level information is public but expensive to track; a static supplier→customer map plus customer-side returns recovers the diffusion premium with low turnover."
+    why_it_fails = "Requires accurate relationship data — stale or thin maps push noise into the signal. Macro shocks that hit customers and suppliers simultaneously kill the lead/lag."
+
+    def __init__(self, customer_lookback_days: int = 21, min_customers: int = 1):
+        self.customer_lookback_days = customer_lookback_days
+        self.min_customers = min_customers
+
+    def generate_scores(self, dataset: ResearchDataset) -> pd.DataFrame:
+        prices = dataset.prices
+        # Customer recent return = past N-day total return on the customer's stock.
+        customer_returns = prices.pct_change(self.customer_lookback_days, fill_method=None)
+        scores = pd.DataFrame(np.nan, index=prices.index, columns=prices.columns, dtype=float)
+        for supplier, customers in CUSTOMER_SUPPLIER_RELATIONSHIPS.items():
+            if supplier not in scores.columns:
+                continue
+            tracked = [c for c in customers if c in customer_returns.columns]
+            if len(tracked) < self.min_customers:
+                continue
+            cust_panel = customer_returns[tracked]
+            valid_count = cust_panel.notna().sum(axis=1)
+            avg = cust_panel.mean(axis=1, skipna=True)
+            scores[supplier] = avg.where(valid_count >= self.min_customers)
+        return scores
+
+
+class PEADStrategy(SignalStrategy):
+    name = "Post-Earnings Announcement Drift"
+    motivation = "Stocks with positive earnings surprises drift up for weeks; negative-surprise names drift down."
+    economic_rationale = "Bernard & Thomas (1989): the market underreacts to the information content of an earnings announcement, releasing the signal gradually over the following 60 trading days."
+    why_it_works = "Standardised Unexpected Earnings (SUE) is a clean cross-sectional ranking that turns over only on announcement dates, so transaction-cost drag is bounded."
+    why_it_fails = "Crowded over time — top-decile drift has shrunk in liquid large caps; pre-announcement leakage and analyst-cluster noise eat the signal at higher frequencies."
+
+    uses_event_data = True
+    event_type = "anncdate"
+
+    _events_cache: Optional[pd.DataFrame] = None
+
+    def __init__(self, holding_days: int = 60):
+        self.holding_days = holding_days
+
+    @classmethod
+    def _load_events(cls) -> pd.DataFrame:
+        if cls._events_cache is not None:
+            return cls._events_cache
+        from pathlib import Path
+        path = Path(__file__).resolve().parent.parent / "backtester" / "surprise earning.csv"
+        if not path.exists():
+            cls._events_cache = pd.DataFrame(columns=["ticker", "anndats", "suescore"])
+            return cls._events_cache
+        df = pd.read_csv(path, usecols=["TICKER", "OFTIC", "anndats", "suescore"])
+        # OFTIC is the standard exchange ticker; TICKER is the WRDS internal id
+        # (e.g. ARRA for Agilent). Prefer OFTIC, fall back to TICKER.
+        df["ticker"] = df["OFTIC"].fillna(df["TICKER"]).astype(str).str.upper().str.replace(".", "-", regex=False)
+        df["anndats"] = pd.to_datetime(df["anndats"], errors="coerce")
+        df = df.dropna(subset=["anndats", "suescore", "ticker"])
+        df = df[["ticker", "anndats", "suescore"]].sort_values(["ticker", "anndats"])
+        cls._events_cache = df
+        return df
+
+    def generate_scores(self, dataset: ResearchDataset) -> pd.DataFrame:
+        events = self._load_events()
+        prices = dataset.prices
+        scores = pd.DataFrame(np.nan, index=prices.index, columns=prices.columns, dtype=float)
+        if events.empty:
+            return scores
+        index = prices.index
+        if not index.is_monotonic_increasing:
+            index = index.sort_values()
+        relevant = events[events["ticker"].isin(prices.columns)]
+        relevant = relevant[(relevant["anndats"] >= index.min()) & (relevant["anndats"] <= index.max())]
+        for ticker, sub in relevant.groupby("ticker"):
+            col = scores[ticker].copy()
+            for ann_date, sue in zip(sub["anndats"].values, sub["suescore"].values):
+                # Find the next trading day on or after the announcement.
+                pos = index.searchsorted(pd.Timestamp(ann_date), side="left")
+                if pos >= len(index):
+                    continue
+                end = min(pos + self.holding_days, len(index))
+                col.iloc[pos:end] = float(sue)
+            scores[ticker] = col
+        return scores
+
+
+class MovingAverageCrossoverStrategy(SignalStrategy):
+    name = "Moving Average Crossover"
+    motivation = "Long names whose short EMA has crossed above the long EMA — a classic trend-following signal."
+    economic_rationale = "Trend-following monetises momentum at the single-name level: when fast moving averages lead slow ones, recent demand has been outpacing supply."
+    why_it_works = "Cross-sectionally, the EMA spread captures persistent trends without the look-ahead of a fitted model; pairing with a low rebalance frequency keeps turnover manageable."
+    why_it_fails = "Choppy or mean-reverting regimes whipsaw the signal; transaction costs and signal lag can wipe out the edge."
+
+    def __init__(self, short_window: int = 50, long_window: int = 200):
+        self.short_window = short_window
+        self.long_window = long_window
+
+    def generate_scores(self, dataset: ResearchDataset) -> pd.DataFrame:
+        prices = dataset.prices
+        short_ema = prices.ewm(span=self.short_window, adjust=False, min_periods=self.short_window).mean()
+        long_ema = prices.ewm(span=self.long_window, adjust=False, min_periods=self.long_window).mean()
+        # Normalised EMA spread: positive = bullish trend, negative = bearish.
+        return (short_ema - long_ema).div(long_ema.replace(0, np.nan))
+
+
 class MLRidgeStrategy(SignalStrategy):
     name = "ML Ridge (rolling OLS)"
     motivation = "Let a rolling ridge regression blend momentum, short-term reversal, volatility, and market beta rather than hand-picking weights."


### PR DESCRIPTION
## Summary
- **Strategy catalog grows from 2 → 5**: registers Moving Average, Customer-Supplier Momentum (Cohen & Frazzini 2008, with curated supplier→customer map), and PEAD (Bernard & Thomas 1989, reads `surprise earning.csv` for SUE) in the simulator catalog. Each entry carries an explicit formula and short_quantile override so the UI can drop the long-only assumption.
- **CombinedOrderGenerator** (`strategies/combined.py`): merges orders from any subset of the five OrderGenerator-style strategies under a per-child capital weight (default 1/N). BUY fractions, fractional SELLs below 1.0 (PairsTrading's short leg), and integer share counts are scaled to the child's slice; `SELL 1.0` passes through so children can still fully close. Wired into `main.py` as menu option 5.
- **Backend hardening**: `warmup` is load-token-aware and `ensure_ready(source)` blocks until the requested data source is loaded — concurrent source switches no longer race.
- **Run payload extended**: `cumulative_drawdown`, `cumulative_drawdown_benchmark`, and a `{year, month, ret}` monthly-returns list now ship with every run response so the frontend can render tearsheet panels without a second round trip.
- **Header overflow fix**: 10 strategy tabs (SECTOR-NEUTRAL DIV YIELD, BETTING AGAINST, …) were wrapping inside the 34px topbar; now they nowrap with horizontal scroll. Plus ticker-table fixed-column layout and `!important` on responsive metric-card borders.

## Test plan
- [x] Python AST parse + import smoke test on `main.py`, `simulation/backend/{server,simulator}.py`, `strategies/{combined,research_strategies}.py`
- [x] `tsc --noEmit` clean on `simulation/frontend/app.ts`
- [x] CombinedOrderGenerator end-to-end: synthetic 4y / 6-ticker panel through `EquityBacktestEngine` — orders generated by all 4 children, weights applied to BUYs and short-leg SELLs, engine consumes the merged stream.
- [ ] Vercel preview build green
- [ ] Pull up the live UI: confirm header tabs no longer wrap, table columns stable, drawdown/monthly-returns reach the frontend.