### PR TITLE
Signal preview + working hotkeys

### DIFF
--- a/simulation/backend/server.py
+++ b/simulation/backend/server.py
@@ -208,6 +208,17 @@ class Handler(BaseHTTPRequestHandler):
                 self._send_json({"error": str(exc)}, status=400)
             return
 
+        if path == "/api/signal/preview":
+            try:
+                result = simulator.signal_preview(body)
+                self._send_json(result)
+            except RuntimeError as exc:
+                self._send_json({"error": str(exc), "status": simulator.status()}, status=409)
+            except Exception as exc:
+                traceback.print_exc()
+                self._send_json({"error": str(exc)}, status=400)
+            return
+
         self.send_error(404, "unknown endpoint")
 
 

--- a/simulation/backend/simulator.py
+++ b/simulation/backend/simulator.py
@@ -824,6 +824,99 @@ def run_simulation(body: Dict[str, Any]) -> Dict[str, Any]:
     return response
 
 
+def signal_preview(body: Dict[str, Any]) -> Dict[str, Any]:
+    """Run the strategy's score function on the latest available date and
+    return the top-N longs / bottom-N shorts, with current price for
+    display. Skips the full backtest — just a single forward pass through
+    `strategy.generate(dataset).scores`.
+    """
+    requested_source = body.get("data_source") or body.get("source")
+    if requested_source:
+        ensure_ready(requested_source)
+    with _LOCK:
+        if not _STATE["ready"]:
+            raise RuntimeError("simulator not ready — wait for warmup")
+        dataset = _STATE["dataset"]
+
+    strategy_id = body.get("strategy_id", "momentum")
+    if strategy_id not in STRATEGY_BY_ID:
+        raise ValueError(f"unknown strategy_id: {strategy_id}")
+    strat_entry = STRATEGY_BY_ID[strategy_id]
+
+    strategy_params = body.get("strategy_params", {}) or {}
+    kw_allowed = {p["name"] for p in strat_entry["params"]}
+    strat_kwargs = {k: strategy_params[k] for k in kw_allowed if k in strategy_params}
+    strat_instance = strat_entry["cls"](**strat_kwargs)
+
+    top_n = int(body.get("top_n") or 10)
+    top_n = max(1, min(50, top_n))
+    short_quantile = float(
+        (body.get("engine_overrides") or {}).get("short_quantile", 0.0)
+    )
+    include_shorts = short_quantile > 0.0
+
+    try:
+        signal = strat_instance.generate(dataset)
+    except Exception as exc:
+        raise RuntimeError(f"strategy.generate failed: {exc}") from exc
+
+    scores = signal.scores
+    if scores is None or scores.empty:
+        return {
+            "as_of": None, "longs": [], "shorts": [], "include_shorts": include_shorts,
+            "strategy_id": strategy_id, "n_universe": 0,
+        }
+
+    # Find the last row with at least N finite values; walk backwards a few
+    # days if today's row is mostly NaN (e.g. weekends, holidays, partial
+    # data on the trailing edge).
+    last_row = None
+    last_date = None
+    for ts in scores.index[::-1]:
+        row = scores.loc[ts].dropna()
+        if len(row) >= max(top_n, 5):
+            last_row = row
+            last_date = ts
+            break
+    if last_row is None:
+        return {
+            "as_of": None, "longs": [], "shorts": [], "include_shorts": include_shorts,
+            "strategy_id": strategy_id, "n_universe": 0,
+        }
+
+    sorted_desc = last_row.sort_values(ascending=False)
+    n = len(sorted_desc)
+
+    last_prices = dataset.prices.loc[last_date] if last_date in dataset.prices.index else dataset.prices.iloc[-1]
+
+    def _row(ticker: str, score: float, rank: int) -> Dict[str, Any]:
+        price = last_prices.get(ticker)
+        return {
+            "ticker": ticker,
+            "score": float(score),
+            "rank": rank,
+            "last_price": float(price) if pd.notna(price) else None,
+        }
+
+    longs = [_row(t, s, i + 1) for i, (t, s) in enumerate(sorted_desc.head(top_n).items())]
+    shorts: List[Dict[str, Any]] = []
+    if include_shorts:
+        # Bottom-N (worst scores). Rank from the bottom upwards: rank 1 = worst.
+        bottom = sorted_desc.tail(top_n).iloc[::-1]
+        shorts = [_row(t, s, i + 1) for i, (t, s) in enumerate(bottom.items())]
+
+    return {
+        "as_of": str(last_date.date()) if hasattr(last_date, "date") else str(last_date),
+        "longs": longs,
+        "shorts": shorts,
+        "include_shorts": include_shorts,
+        "strategy_id": strategy_id,
+        "strategy_label": strat_entry["label"],
+        "n_universe": int(n),
+        "top_n": top_n,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Data inspector
 # ---------------------------------------------------------------------------

--- a/simulation/frontend/app.ts
+++ b/simulation/frontend/app.ts
@@ -205,6 +205,24 @@ interface SimRequest {
   data_source?: string;
 }
 
+interface SignalRow {
+  ticker: string;
+  score: number;
+  rank: number;
+  last_price: number | null;
+}
+
+interface SignalPreview {
+  as_of: string | null;
+  longs: SignalRow[];
+  shorts: SignalRow[];
+  include_shorts: boolean;
+  strategy_id: string;
+  strategy_label?: string;
+  n_universe: number;
+  top_n?: number;
+}
+
 interface PinnedRun {
   id: string;
   label: string;          // user-editable; auto-generated from strategy + params
@@ -889,6 +907,9 @@ result  = run_weight_backtest(dataset.prices, weights, config,
       lastRender.simPayload = body as unknown as SimRequest;
       renderResults(data);
       setStatus(`ready · last run ${(elapsed / 1000).toFixed(2)}s`, "ready");
+      // Fire-and-forget signal preview — non-blocking, errors are logged
+      // not surfaced (the main result already landed).
+      fetchSignalPreview(p).catch((e) => console.error("signal_preview", e));
     } catch (exc) {
       console.error(exc);
       const msg = exc instanceof Error ? exc.message : String(exc);
@@ -1300,6 +1321,87 @@ result  = run_weight_backtest(dataset.prices, weights, config,
       );
       host.appendChild(chip);
     }
+  }
+
+  async function fetchSignalPreview(p: RunPayload): Promise<void> {
+    if (!state.currentStrategy) return;
+    const body = {
+      strategy_id: state.currentStrategy.id,
+      strategy_params: p.strategyParams,
+      engine_overrides: p.engineOverrides,
+      data_source: state.dataSource,
+      top_n: 10,
+    };
+    try {
+      const res = await fetch("/api/signal/preview", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        renderSignalPreview(null);
+        return;
+      }
+      const data = (await res.json()) as SignalPreview;
+      renderSignalPreview(data);
+    } catch (_) {
+      renderSignalPreview(null);
+    }
+  }
+
+  function renderSignalPreview(data: SignalPreview | null): void {
+    const host = document.getElementById("signal-preview");
+    const sub = document.getElementById("signal-sub");
+    if (!host) return;
+    if (!data || (!data.longs.length && !data.shorts.length)) {
+      host.innerHTML = `<div class="signal-empty">No signal data for the latest date.</div>`;
+      return;
+    }
+    if (sub) {
+      const dateStr = data.as_of || "—";
+      const universe = data.n_universe ? `${data.n_universe} names` : "";
+      sub.textContent = `as of ${dateStr}${universe ? " · " + universe : ""}`;
+    }
+    const fmtScore = (s: number): string =>
+      Math.abs(s) >= 100 ? s.toFixed(1)
+      : Math.abs(s) >= 10 ? s.toFixed(2)
+      : s.toFixed(4);
+    const fmtPrice = (p: number | null): string =>
+      p == null ? "—" : `$${p >= 1000 ? p.toFixed(0) : p.toFixed(2)}`;
+    const longRows = data.longs
+      .map(
+        (r) => `
+        <tr>
+          <td class="sp-rank">${r.rank}</td>
+          <td class="sp-tic">${escapeHtml(r.ticker)}</td>
+          <td class="sp-score gain">${fmtScore(r.score)}</td>
+          <td class="sp-px">${fmtPrice(r.last_price)}</td>
+        </tr>`,
+      )
+      .join("");
+    const shortRows = data.shorts
+      .map(
+        (r) => `
+        <tr>
+          <td class="sp-rank">${r.rank}</td>
+          <td class="sp-tic">${escapeHtml(r.ticker)}</td>
+          <td class="sp-score loss">${fmtScore(r.score)}</td>
+          <td class="sp-px">${fmtPrice(r.last_price)}</td>
+        </tr>`,
+      )
+      .join("");
+    const longsCol = `
+      <div class="sp-col sp-longs">
+        <div class="sp-col-head">▎ TOP ${data.longs.length} LONGS</div>
+        <table class="sp-table"><tbody>${longRows}</tbody></table>
+      </div>`;
+    const shortsCol = data.include_shorts && data.shorts.length
+      ? `<div class="sp-col sp-shorts">
+           <div class="sp-col-head">▎ BOTTOM ${data.shorts.length} SHORTS</div>
+           <table class="sp-table"><tbody>${shortRows}</tbody></table>
+         </div>`
+      : "";
+    host.innerHTML = longsCol + shortsCol;
   }
 
   function renderMonthlyHeatmap(monthly: MonthlyReturn[]): void {
@@ -1951,9 +2053,103 @@ result  = run_weight_backtest(dataset.prices, weights, config,
     });
   }
 
+  function isInputFocused(): boolean {
+    const el = document.activeElement as HTMLElement | null;
+    if (!el) return false;
+    const tag = el.tagName;
+    if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+    if (el.isContentEditable) return true;
+    return false;
+  }
+
+  function bindHotkeys(): void {
+    document.addEventListener("keydown", (ev) => {
+      // Esc — always works, clears toast and blurs current input.
+      if (ev.key === "Escape") {
+        const t = document.getElementById("toast");
+        if (t) t.classList.add("hidden");
+        if (document.activeElement && (document.activeElement as HTMLElement).blur) {
+          (document.activeElement as HTMLElement).blur();
+        }
+        return;
+      }
+      // Slash — focus the ticker search (only when not already in an input).
+      if (ev.key === "/" && !isInputFocused()) {
+        ev.preventDefault();
+        const search = document.getElementById("ticker-search") as HTMLInputElement | null;
+        if (search) {
+          search.focus();
+          search.select();
+        }
+        return;
+      }
+      // Cmd/Ctrl + P — pin current run.
+      if ((ev.metaKey || ev.ctrlKey) && (ev.key === "p" || ev.key === "P") && !ev.shiftKey) {
+        ev.preventDefault();
+        pinCurrentRun();
+        return;
+      }
+      // Cmd/Ctrl + Shift + R — reset every visible param to its default.
+      if ((ev.metaKey || ev.ctrlKey) && ev.shiftKey && (ev.key === "R" || ev.key === "r")) {
+        ev.preventDefault();
+        resetAllParams();
+        return;
+      }
+      // Enter — run (only when no input is focused; inputs already have
+      // their own change handlers that schedule a run).
+      if (ev.key === "Enter" && !isInputFocused() && !ev.metaKey && !ev.ctrlKey) {
+        ev.preventDefault();
+        scheduleRun();
+        return;
+      }
+      // 1-9 — switch strategy by index (only when not in an input).
+      if (!isInputFocused() && !ev.metaKey && !ev.ctrlKey && !ev.altKey) {
+        const n = parseInt(ev.key, 10);
+        if (Number.isFinite(n) && n >= 1 && n <= 9) {
+          const strategies = state.catalog?.strategies || [];
+          if (n - 1 < strategies.length) {
+            ev.preventDefault();
+            selectStrategy(strategies[n - 1].id);
+          }
+        }
+      }
+    });
+  }
+
+  function resetAllParams(): void {
+    if (!state.currentStrategy || !state.catalog) return;
+    let changed = 0;
+    const writeDefault = (id: string, val: number): void => {
+      const el = document.getElementById(id) as HTMLInputElement | null;
+      if (!el) return;
+      if (parseFloat(el.value) !== val) {
+        el.value = String(val);
+        el.dispatchEvent(new Event("input", { bubbles: true }));
+        changed += 1;
+      }
+    };
+    for (const p of state.currentStrategy.params) {
+      writeDefault(`strat-${p.name}`, p.default);
+    }
+    for (const p of state.currentStrategy.engine_overrides || []) {
+      writeDefault(`ovr-${p.name}`, p.default);
+    }
+    for (const p of state.catalog.engine_params) {
+      writeDefault(`eng-${p.name}`, p.default);
+    }
+    if (changed) {
+      toast(`reset ${changed} param${changed === 1 ? "" : "s"} to defaults`, false, 2000);
+      renderLiveCode();
+      scheduleRun();
+    } else {
+      toast("already at defaults", false, 1500);
+    }
+  }
+
   (async (): Promise<void> => {
     setStatus("connecting…", "loading");
     renderPinnedList();
+    bindHotkeys();
     try {
       if (!(await waitReady())) return;
       state.catalog = await loadCatalog();

--- a/simulation/frontend/index.html
+++ b/simulation/frontend/index.html
@@ -98,6 +98,16 @@
 
         <div class="panel">
           <header class="panel-head">
+            <h3>Signal preview</h3>
+            <span class="panel-sub" id="signal-sub">strategy scores at the latest available date</span>
+          </header>
+          <div class="signal-preview" id="signal-preview">
+            <div class="signal-empty">Run a backtest to see the live signal ranking.</div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <header class="panel-head">
             <h3>Equity curve</h3>
             <div class="panel-actions">
               <button id="pin-current" class="ghost-btn" type="button" title="pin the current run as a comparison curve on this chart">

--- a/simulation/frontend/style.css
+++ b/simulation/frontend/style.css
@@ -775,6 +775,69 @@ a:hover { color: var(--amber-hot); text-decoration: underline; }
 /* ---- Charts ---- */
 .chart { height: 540px; padding: 10px 12px 6px; }
 .heatmap-chart { padding: 10px 14px 14px; min-height: 180px; }
+
+/* ---- Signal preview — top-N longs / bottom-N shorts at latest date ---- */
+.signal-preview {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  background: var(--border);
+}
+.signal-preview .sp-col {
+  background: var(--panel);
+  padding: 12px 14px 14px;
+}
+.signal-preview .sp-col-head {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+.signal-preview .sp-longs .sp-col-head { color: var(--gain); }
+.signal-preview .sp-shorts .sp-col-head { color: var(--loss); }
+.signal-preview .sp-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 13px;
+}
+.signal-preview .sp-table td {
+  padding: 4px 6px;
+  border-bottom: 1px solid var(--border-soft);
+  color: var(--text);
+  height: 26px;
+}
+.signal-preview .sp-table tr:last-child td { border-bottom: 0; }
+.signal-preview .sp-rank {
+  width: 32px;
+  color: var(--text-3);
+  font-size: 11px;
+  text-align: right;
+}
+.signal-preview .sp-tic {
+  font-weight: 600;
+  color: var(--amber);
+  letter-spacing: 0.04em;
+}
+.signal-preview .sp-score { text-align: right; }
+.signal-preview .sp-score.gain { color: var(--gain); }
+.signal-preview .sp-score.loss { color: var(--loss); }
+.signal-preview .sp-px { text-align: right; color: var(--text-2); }
+.signal-empty {
+  grid-column: 1 / -1;
+  padding: 16px 18px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-3);
+  background: var(--panel);
+}
+@media (max-width: 900px) {
+  .signal-preview { grid-template-columns: 1fr; }
+}
+
 .figure-cap { display: none; }
 .dingbat { display: none; }
 
@@ -1126,7 +1189,7 @@ a:hover { color: var(--amber-hot); text-decoration: underline; }
   margin-right: 6px;
 }
 .statusbar::after {
-  content: "F1·HELP   F2·SIM   F3·DATA   F5·RUN   ESC·CLEAR";
+  content: "ENTER·RUN   ⌘P·PIN   ⌘⇧R·RESET   1-9·STRATEGY   /·SEARCH   ESC·CLEAR";
   margin-left: auto;
   color: var(--text-mute);
   letter-spacing: 0.2em;


### PR DESCRIPTION
Final two workstreams from the depth plan:

- **D**: live signal preview — top-10 longs / bottom-10 shorts at the latest date, mono-tabular table between metrics and equity chart, auto-refreshes on every run
- **F**: working keyboard shortcuts — Enter runs, ⌘P pins, ⌘⇧R resets all params, 1-9 switches strategy, / focuses ticker search, Esc clears

Status bar F-key hint strip rewritten to match what's actually wired.