### PR TITLE
fix(simulation): include SUE event panel in docker image (PEAD 502)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -43,3 +43,6 @@ backtester/*.txt
 backtester/*.csv
 backtester/wharton_alias_report_summary.txt
 backtester/spy_wharton4_verification_report.txt
+
+# …except the SUE event panel — PEADStrategy reads this at runtime.
+!backtester/surprise earning.csv

--- a/strategies/research_strategies.py
+++ b/strategies/research_strategies.py
@@ -348,8 +348,11 @@ class PEADStrategy(SignalStrategy):
         from pathlib import Path
         path = Path(__file__).resolve().parent.parent / "backtester" / "surprise earning.csv"
         if not path.exists():
-            cls._events_cache = pd.DataFrame(columns=["ticker", "anndats", "suescore"])
-            return cls._events_cache
+            raise FileNotFoundError(
+                f"PEAD requires {path.name} (the SUE event panel) but it was "
+                f"not found at {path}. If running in Docker, check .dockerignore "
+                f"isn't excluding backtester/*.csv."
+            )
         df = pd.read_csv(path, usecols=["TICKER", "OFTIC", "anndats", "suescore"])
         # OFTIC is the standard exchange ticker; TICKER is the WRDS internal id
         # (e.g. ARRA for Agilent). Prefer OFTIC, fall back to TICKER.


### PR DESCRIPTION
## Summary
PEAD strategy returns 502 in prod because `.dockerignore`'s `backtester/*.csv` blanket rule excluded `surprise earning.csv` from the deployed image. PEAD silently fell through to the missing-file path → empty events → all-NaN scores → backtester crash → 502.

- Whitelist `backtester/surprise earning.csv` after the blanket csv exclusion.
- Replace PEAD's silent empty-DataFrame fallback with an explicit `FileNotFoundError` so this never silently 502s again.

## Test plan
- [ ] Vercel preview / Fly deploy: select Post-Earnings Announcement Drift, hit run, verify a non-empty equity curve.
- [ ] Confirm yfinance and Wharton sources both work for PEAD.