### PR TITLE
Add Value Composite + Residual Momentum (replace LowVol)

### DIFF
--- a/simulation/backend/simulator.py
+++ b/simulation/backend/simulator.py
@@ -206,20 +206,30 @@ STRATEGIES = [
         ],
     },
     {
-        "id": "low_volatility",
-        "cls": rs.LowVolatilityStrategy,
-        "cls_name": "LowVolatilityStrategy",
-        "label": "Low Volatility",
-        "formula": "score(t, i) = − σ_window( returns(i) )",
+        "id": "residual_momentum",
+        "cls": rs.ResidualMomentumStrategy,
+        "cls_name": "ResidualMomentumStrategy",
+        "label": "Residual Momentum",
+        "formula": (
+            "ε_i(t) = r_i(t) − β_i(t)·r_m(t);   "
+            "score(t, i) = ⟨ ε_i(τ) / σ̂_ε,i(τ) ⟩  for  τ ∈ [t − skip − lookback, t − skip]"
+        ),
         "summary": (
-            "Frazzini & Pedersen (2014, 'Betting Against Beta'); Baker, "
-            "Bradley & Wurgler (2011). The low-volatility anomaly: hold the "
-            "lowest-realized-vol names, short the highest. Score is negative "
-            "rolling-window standard deviation of daily returns."
+            "Blitz, Huij & Martens (2011, JFE). Regress each stock's daily "
+            "returns on the equal-weight benchmark over a rolling window, "
+            "standardize the residuals by their own rolling std, then take "
+            "the mean of those standardized residuals over a 12-1-style "
+            "lookback (skipping the most recent month). Same direction as "
+            "vanilla momentum but with market beta residualized away — "
+            "survives the 2009-style momentum crash that punishes raw 12-1."
         ),
         "params": [
-            {"name": "window", "type": "int", "default": 126, "min": 21, "max": 252, "step": 21,
-             "help": "Rolling window for realized volatility (126 ≈ 6mo)."},
+            {"name": "beta_window", "type": "int", "default": 252, "min": 63, "max": 504, "step": 21,
+             "help": "Rolling window for market-beta regression (252 ≈ 1y)."},
+            {"name": "lookback_days", "type": "int", "default": 126, "min": 21, "max": 252, "step": 21,
+             "help": "Window for averaging standardized residuals (126 ≈ 6mo)."},
+            {"name": "skip_days", "type": "int", "default": 21, "min": 0, "max": 63, "step": 1,
+             "help": "Skip the most recent N days to avoid short-term reversal contamination."},
         ],
         "engine_overrides": [_SHORT_QUANTILE_OVERRIDE],
     },

--- a/strategies/research_strategies.py
+++ b/strategies/research_strategies.py
@@ -242,6 +242,75 @@ class ShortTermReversalStrategy(SignalStrategy):
         return -(dataset.prices.div(dataset.prices.shift(self.lookback_days)) - 1.0)
 
 
+class ResidualMomentumStrategy(SignalStrategy):
+    name = "Residual Momentum"
+    motivation = "Buy names with strong recent returns *after* stripping out exposure to the market."
+    economic_rationale = (
+        "Blitz, Huij & Martens (2011): vanilla 12-1 momentum is partly a "
+        "compensation for high-beta exposure. Regressing each stock's daily "
+        "returns on the market and ranking by the recent *residual* mean "
+        "isolates the slow-information-diffusion channel and decorrelates "
+        "the signal from broad-market beta."
+    )
+    why_it_works = (
+        "Higher Sharpe than raw momentum across decades; smaller drawdowns "
+        "during momentum crashes (e.g. March 2009) because market-beta "
+        "exposure has been residualized away."
+    )
+    why_it_fails = (
+        "Estimation error in rolling beta on names with thin history; "
+        "structural breaks in factor structure (e.g. the COVID drawdown "
+        "regime) can leave residuals contaminated until the window rolls."
+    )
+
+    def __init__(
+        self,
+        beta_window: int = 252,
+        lookback_days: int = 126,
+        skip_days: int = 21,
+    ):
+        self.beta_window = beta_window
+        self.lookback_days = lookback_days
+        self.skip_days = skip_days
+
+    def generate_scores(self, dataset: ResearchDataset) -> pd.DataFrame:
+        returns = dataset.returns
+        market = dataset.benchmark_returns
+        if returns is None or returns.empty or market is None or market.empty:
+            return pd.DataFrame(index=returns.index, columns=returns.columns, dtype=float)
+
+        # Vectorized rolling beta: cov_i(t) = rolling_cov(r_i, r_m); var_m(t) = rolling_var(r_m)
+        # Pandas: df.rolling(W).cov(series) returns a DataFrame where each
+        # column is the rolling covariance of that column with the series.
+        rolling_cov = returns.rolling(self.beta_window, min_periods=self.beta_window // 2).cov(market)
+        rolling_var = market.rolling(self.beta_window, min_periods=self.beta_window // 2).var()
+        beta = rolling_cov.div(rolling_var.replace(0, np.nan), axis=0)
+
+        # Residuals: r_i(t) − β_i(t) · r_m(t). Drop the drifting alpha
+        # intercept — for daily data over our window it's near-zero and
+        # introduces only noise.
+        expected = beta.mul(market, axis=0)
+        residuals = returns.subtract(expected)
+
+        # Standardize residuals by their own rolling std so high-vol names
+        # don't dominate the cross-section purely on noise (BHM normalize
+        # at the *signal* step, not the score step — same idea).
+        res_std = residuals.rolling(
+            self.beta_window, min_periods=self.beta_window // 2,
+        ).std().replace(0, np.nan)
+        standardized = residuals.div(res_std)
+
+        # 12-1 style signal — average standardized residual over the
+        # lookback window, skipping the most recent skip_days to avoid
+        # short-term reversal contamination.
+        score = (
+            standardized.shift(self.skip_days)
+            .rolling(self.lookback_days, min_periods=max(self.lookback_days // 2, 1))
+            .mean()
+        )
+        return score
+
+
 class LowVolatilityStrategy(SignalStrategy):
     name = "Low Volatility"
     motivation = "Hold the lowest-volatility names, exploiting the low-vol anomaly."


### PR DESCRIPTION
Two paper-backed strategies bringing the catalog to 7:

- **Value Composite** (Fama-French 1992/2015) — `z(div_yield) + z(EPS/P) + z(-log mcap)`
- **Residual Momentum** (Blitz, Huij & Martens 2011, JFE) — vanilla 12-1 momentum with market beta residualized via rolling regression

Replaces the Low Volatility entry that was too vanilla for the presentation review. Coverage now spans price-only, technical, relational, event-based, fundamental, and risk-residualized signal classes.