### PR TITLE
Always-editable code panel + trim catalog to 5

### DIFF
--- a/simulation/backend/simulator.py
+++ b/simulation/backend/simulator.py
@@ -108,45 +108,66 @@ _SHORT_QUANTILE_OVERRIDE = {
 
 STRATEGIES = [
     {
-        "id": "momentum",
-        "cls": rs.CrossSectionalMomentumStrategy,
-        "cls_name": "CrossSectionalMomentumStrategy",
-        "label": "Momentum",
-        "formula": "score(t, i) = ln( P[t − skip, i] / P[t − lookback, i] )",
-        "summary": "Rank stocks by their return from (today − lookback_days) to (today − skip_days); long the top quantile, optionally short the bottom.",
+        "id": "value_composite",
+        "cls": rs.ValueCompositeStrategy,
+        "cls_name": "ValueCompositeStrategy",
+        "label": "Value Composite",
+        "formula": "score(t, i) = z(div_yield) + z(EPS / P) + z(− log market_cap)",
+        "summary": (
+            "Fama & French (1992, 2015 — Five-Factor Model). Cross-sectional "
+            "value blend of trailing dividend yield, earnings yield (E/P), and "
+            "a small-size tilt, each cross-sectionally z-scored and summed. "
+            "Long the cheapest decile, optionally short the most expensive."
+        ),
         "params": [
-            {"name": "lookback_days", "type": "int", "default": 126, "min": 21, "max": 504, "step": 21,
-             "help": "Return window (126 ≈ 6mo)."},
-            {"name": "skip_days",     "type": "int", "default": 21,  "min": 0,  "max": 63,  "step": 1,
-             "help": "Skip last N days to drop short-term reversal (21 ≈ 1mo)."},
+            {"name": "trailing_days", "type": "int", "default": 252, "min": 60, "max": 756, "step": 21,
+             "help": "Window for trailing dividend sum (252 = 1y)."},
         ],
-        "engine_overrides": [_SHORT_QUANTILE_OVERRIDE],
-    },
-    {
-        "id": "mean_reversion",
-        "cls": rs.ShortTermReversalStrategy,
-        "cls_name": "ShortTermReversalStrategy",
-        "label": "Mean Reversion",
-        "formula": "score(t, i) = − ln( P[t, i] / P[t − lookback, i] )",
-        "summary": "Score stocks by their negated recent return; long the biggest recent losers, expecting a bounce.",
-        "params": [
-            {"name": "lookback_days", "type": "int", "default": 5, "min": 1, "max": 21, "step": 1,
-             "help": "Recent-return window; biggest losers rank highest."},
+        "engine_overrides": [
+            {**_SHORT_QUANTILE_OVERRIDE, "default": 0.10,
+             "help": "Bottom decile (most expensive names) sold short — recovers the long-short HML sleeve."},
         ],
-        "engine_overrides": [_SHORT_QUANTILE_OVERRIDE],
     },
     {
         "id": "moving_average",
         "cls": rs.MovingAverageCrossoverStrategy,
         "cls_name": "MovingAverageCrossoverStrategy",
-        "label": "Moving Average",
-        "formula": "score(t, i) = EMA_short(P, t, i) / EMA_long(P, t, i) − 1",
-        "summary": "Cross-sectional EMA crossover — score = (short EMA − long EMA) / long EMA. Long names in the strongest uptrend, short the weakest.",
+        "label": "Simple Moving Average",
+        "formula": "score(t, i) = MA_short(P, t, i) / MA_long(P, t, i) − 1",
+        "summary": "Cross-sectional moving-average crossover. Long names in the strongest uptrend (short MA above long MA), short the weakest.",
         "params": [
             {"name": "short_window", "type": "int", "default": 50,  "min": 5,  "max": 100, "step": 5,
-             "help": "Span of the fast EMA."},
+             "help": "Span of the fast moving average."},
             {"name": "long_window",  "type": "int", "default": 200, "min": 50, "max": 400, "step": 10,
-             "help": "Span of the slow EMA."},
+             "help": "Span of the slow moving average."},
+        ],
+        "engine_overrides": [_SHORT_QUANTILE_OVERRIDE],
+    },
+    {
+        "id": "residual_momentum",
+        "cls": rs.ResidualMomentumStrategy,
+        "cls_name": "ResidualMomentumStrategy",
+        "label": "Residual Momentum",
+        "formula": (
+            "ε_i(t) = r_i(t) − β_i(t)·r_m(t);   "
+            "score(t, i) = ⟨ ε_i(τ) / σ̂_ε,i(τ) ⟩  for  τ ∈ [t − skip − lookback, t − skip]"
+        ),
+        "summary": (
+            "Blitz, Huij & Martens (2011, JFE). Regress each stock's daily "
+            "returns on the equal-weight benchmark over a rolling window, "
+            "standardize the residuals by their own rolling std, then take "
+            "the mean of those standardized residuals over a 12-1-style "
+            "lookback (skipping the most recent month). Same direction as "
+            "vanilla momentum but with market beta residualized away — "
+            "survives the 2009-style momentum crash that punishes raw 12-1."
+        ),
+        "params": [
+            {"name": "beta_window", "type": "int", "default": 252, "min": 63, "max": 504, "step": 21,
+             "help": "Rolling window for market-beta regression (252 ≈ 1y)."},
+            {"name": "lookback_days", "type": "int", "default": 126, "min": 21, "max": 252, "step": 21,
+             "help": "Window for averaging standardized residuals (126 ≈ 6mo)."},
+            {"name": "skip_days", "type": "int", "default": 21, "min": 0, "max": 63, "step": 1,
+             "help": "Skip the most recent N days to avoid short-term reversal contamination."},
         ],
         "engine_overrides": [_SHORT_QUANTILE_OVERRIDE],
     },
@@ -183,55 +204,6 @@ STRATEGIES = [
             {**_SHORT_QUANTILE_OVERRIDE, "default": 0.10,
              "help": "Bottom-decile (negative SUE) names sold short — recovers the canonical long-short PEAD sleeve."},
         ],
-    },
-    {
-        "id": "value_composite",
-        "cls": rs.ValueCompositeStrategy,
-        "cls_name": "ValueCompositeStrategy",
-        "label": "Value Composite",
-        "formula": "score(t, i) = z(div_yield) + z(EPS / P) + z(− log market_cap)",
-        "summary": (
-            "Fama & French (1992, 2015 — Five-Factor Model). Cross-sectional "
-            "value blend of trailing dividend yield, earnings yield (E/P), and "
-            "a small-size tilt, each cross-sectionally z-scored and summed. "
-            "Long the cheapest decile, optionally short the most expensive."
-        ),
-        "params": [
-            {"name": "trailing_days", "type": "int", "default": 252, "min": 60, "max": 756, "step": 21,
-             "help": "Window for trailing dividend sum (252 = 1y)."},
-        ],
-        "engine_overrides": [
-            {**_SHORT_QUANTILE_OVERRIDE, "default": 0.10,
-             "help": "Bottom decile (most expensive names) sold short — recovers the long-short HML sleeve."},
-        ],
-    },
-    {
-        "id": "residual_momentum",
-        "cls": rs.ResidualMomentumStrategy,
-        "cls_name": "ResidualMomentumStrategy",
-        "label": "Residual Momentum",
-        "formula": (
-            "ε_i(t) = r_i(t) − β_i(t)·r_m(t);   "
-            "score(t, i) = ⟨ ε_i(τ) / σ̂_ε,i(τ) ⟩  for  τ ∈ [t − skip − lookback, t − skip]"
-        ),
-        "summary": (
-            "Blitz, Huij & Martens (2011, JFE). Regress each stock's daily "
-            "returns on the equal-weight benchmark over a rolling window, "
-            "standardize the residuals by their own rolling std, then take "
-            "the mean of those standardized residuals over a 12-1-style "
-            "lookback (skipping the most recent month). Same direction as "
-            "vanilla momentum but with market beta residualized away — "
-            "survives the 2009-style momentum crash that punishes raw 12-1."
-        ),
-        "params": [
-            {"name": "beta_window", "type": "int", "default": 252, "min": 63, "max": 504, "step": 21,
-             "help": "Rolling window for market-beta regression (252 ≈ 1y)."},
-            {"name": "lookback_days", "type": "int", "default": 126, "min": 21, "max": 252, "step": 21,
-             "help": "Window for averaging standardized residuals (126 ≈ 6mo)."},
-            {"name": "skip_days", "type": "int", "default": 21, "min": 0, "max": 63, "step": 1,
-             "help": "Skip the most recent N days to avoid short-term reversal contamination."},
-        ],
-        "engine_overrides": [_SHORT_QUANTILE_OVERRIDE],
     },
 ]
 STRATEGY_BY_ID = {s["id"]: s for s in STRATEGIES}

--- a/simulation/frontend/app.ts
+++ b/simulation/frontend/app.ts
@@ -11,9 +11,8 @@ declare const Plotly: {
   ): Promise<unknown>;
   purge(el: string | HTMLElement): void;
 };
-declare const Prism: {
-  highlightElement(el: HTMLElement): void;
-};
+// Prism removed — code panel is now an always-editable textarea, no
+// syntax highlighting layer.
 
 // ---------- API shapes ----------
 interface ParamSpec {
@@ -188,10 +187,8 @@ interface AppState {
   dataSource: string;
   availableSources: string[];
   // Live code editor: per-strategy edited source, keyed by strategy id.
-  // null means "no edit active" — the catalog source is rendered.
+  // Empty/missing means "use the catalog source unchanged".
   editedSourceByStrategy: Record<string, string>;
-  // Whether the editor pane is currently visible (textarea up, pre hidden).
-  editing: boolean;
 }
 
 interface SimRequest {
@@ -281,7 +278,6 @@ type StatusKind = "ready" | "loading" | "error" | "" | undefined;
     dataSource: "yfinance",
     availableSources: ["yfinance", "wharton"],
     editedSourceByStrategy: {},
-    editing: false,
   };
 
   function loadPinnedFromStorage(): PinnedRun[] {
@@ -485,9 +481,8 @@ type StatusKind = "ready" | "loading" | "error" | "" | undefined;
     const s = state.catalog!.strategies.find((x) => x.id === id);
     if (!s) return;
     state.currentStrategy = s;
-    // Switching tabs always exits editor mode — but per-strategy edits are
-    // preserved in editedSourceByStrategy and re-applied on return.
-    state.editing = false;
+    // Per-strategy edits live in editedSourceByStrategy and are re-applied
+    // on return — the textarea repaints from there in renderLiveCode().
     document.querySelectorAll<HTMLButtonElement>("#strategy-tabs button").forEach((b) => {
       b.classList.toggle("active", b.dataset.id === id);
     });
@@ -705,143 +700,92 @@ type StatusKind = "ready" | "loading" | "error" | "" | undefined;
   }
   function renderLiveCode(): void {
     const s = state.currentStrategy!;
-    const { strategyParams, engineParams, engineOverrides } = readParams();
-    const stratArgs = Object.entries(strategyParams)
-      .map(([k, v]) => `    ${k}=${pyRepr(v)},`)
-      .join("\n");
-    // If the user edited the class source, parse the new class name so the
-    // "your run" snippet reflects what actually executes.
-    const editedSrc = state.editedSourceByStrategy[s.id];
-    const editedClsMatch = editedSrc ? editedSrc.match(/class\s+(\w+)\s*\(/) : null;
-    const clsName = editedClsMatch ? editedClsMatch[1] : s.cls_name;
-    const stratCall = stratArgs
-      ? `strategy = ${clsName}(\n${stratArgs}\n)`
-      : `strategy = ${clsName}()`;
-
-    // Merge: live knobs + per-strategy overrides win; fixed defaults fill in.
-    const fixedEngine: Record<string, unknown> = { ...state.catalog!.fixed_engine };
-    for (const k of Object.keys(engineOverrides)) delete fixedEngine[k];
-    if ((engineOverrides.short_quantile ?? 0) > 0) fixedEngine.long_only = false;
-    const mergedLive: Record<string, number> = { ...engineParams, ...engineOverrides };
-
-    const liveCfgLines = Object.entries(mergedLive)
-      .map(([k, v]) => `    ${k}=${pyRepr(v)},`)
-      .join("\n");
-    const fixedLines = Object.entries(fixedEngine)
-      .map(([k, v]) => `    ${k}=${pyRepr(v)},`)
-      .join("\n");
-    const configCall =
-`config = BacktestConfig(
-${liveCfgLines}
-${fixedLines}
-)`;
-
-    const classSource = state.editedSourceByStrategy[s.id] ?? s.source;
-    const full =
-`# ── class source — ${s.source_file}
-${classSource}
-
-# ── your run (live values below)
-${stratCall}
-
-${configCall}
-
-scores  = strategy.generate(dataset).scores
-weights = build_target_weights(scores, dataset.returns, config)
-result  = run_weight_backtest(dataset.prices, weights, config,
-                              benchmark_returns=dataset.benchmark_returns)
-`;
-    const el = $("code-live");
-    el.textContent = full;
-    Prism.highlightElement(el);
-    syncEditButtons();
+    // Always-editable textarea: paint the catalog source (or the user's
+    // last edit, if they've touched this strategy). User changes are
+    // captured by the input listener below; we only re-paint here when
+    // the strategy switches or selection is reset.
+    const editor = $("code-editor") as HTMLTextAreaElement;
+    const stored = state.editedSourceByStrategy[s.id];
+    const targetSrc = stored != null ? stored : s.source;
+    if (editor.value !== targetSrc) {
+      editor.value = targetSrc;
+    }
     updateSizing();
   }
 
-  // ---------- Live code editor ----------
-  function syncEditButtons(): void {
-    const s = state.currentStrategy;
-    const hasEdit = !!(s && state.editedSourceByStrategy[s.id] != null);
-    const status = $("code-edit-status");
-    const toggleBtn = $("code-edit-toggle") as HTMLButtonElement;
-    const runBtn = $("code-edit-run") as HTMLButtonElement;
-    const revertBtn = $("code-edit-revert") as HTMLButtonElement;
-    const editor = $("code-editor") as HTMLTextAreaElement;
-    const pre = document.querySelector(".code-block") as HTMLElement | null;
-
-    if (state.editing) {
-      toggleBtn.textContent = "Cancel";
-      runBtn.hidden = false;
-      revertBtn.hidden = !hasEdit;
-      editor.hidden = false;
-      if (pre) pre.hidden = true;
-      status.textContent = "editing — Cmd+Enter to run";
-    } else {
-      toggleBtn.textContent = hasEdit ? "Edit (modified)" : "Edit";
-      runBtn.hidden = true;
-      revertBtn.hidden = !hasEdit;
-      editor.hidden = true;
-      if (pre) pre.hidden = false;
-      status.textContent = hasEdit ? "running edited code" : "";
-    }
-  }
   function classSourceForCurrent(): string {
     const s = state.currentStrategy!;
     return state.editedSourceByStrategy[s.id] ?? s.source;
   }
-  function enterEditMode(): void {
-    const s = state.currentStrategy;
-    if (!s) return;
-    const editor = $("code-editor") as HTMLTextAreaElement;
-    editor.value = classSourceForCurrent();
-    state.editing = true;
-    syncEditButtons();
-    editor.focus();
+
+  // Debounced auto-commit: every keystroke in the textarea schedules a
+  // re-run after the user pauses typing. Backend's _compile_strategy_override
+  // tolerates a tweaked class — and broken syntax just bubbles back as a
+  // toast, no UI lockup.
+  let codeEditTimer: number | null = null;
+  function scheduleEditedRun(): void {
+    if (codeEditTimer !== null) clearTimeout(codeEditTimer);
+    codeEditTimer = window.setTimeout(() => {
+      const s = state.currentStrategy;
+      if (!s) return;
+      const editor = $("code-editor") as HTMLTextAreaElement;
+      const src = editor.value;
+      const trimmed = src.trim();
+      if (!trimmed) {
+        // Empty-buffer = revert to catalog source.
+        delete state.editedSourceByStrategy[s.id];
+      } else if (trimmed === s.source.trim()) {
+        // Same as the catalog → don't ship an override.
+        delete state.editedSourceByStrategy[s.id];
+      } else {
+        state.editedSourceByStrategy[s.id] = src;
+      }
+      scheduleRun();
+    }, 1200);
   }
-  function exitEditMode(): void {
-    state.editing = false;
-    syncEditButtons();
-  }
-  function runEditedCode(): void {
-    const s = state.currentStrategy;
-    if (!s) return;
-    const editor = $("code-editor") as HTMLTextAreaElement;
-    const src = editor.value;
-    if (!src.trim()) {
-      toast("editor is empty — nothing to run", true);
-      return;
+
+  const codeEditor = $("code-editor") as HTMLTextAreaElement;
+  codeEditor.addEventListener("input", scheduleEditedRun);
+  codeEditor.addEventListener("blur", () => {
+    // On focus loss, commit immediately (no waiting on the debounce).
+    if (codeEditTimer !== null) {
+      clearTimeout(codeEditTimer);
+      codeEditTimer = null;
     }
-    state.editedSourceByStrategy[s.id] = src;
-    state.editing = false;
-    renderLiveCode();
-    scheduleRun();
-  }
-  function revertEdit(): void {
     const s = state.currentStrategy;
     if (!s) return;
-    delete state.editedSourceByStrategy[s.id];
-    state.editing = false;
-    renderLiveCode();
+    const src = codeEditor.value;
+    const trimmed = src.trim();
+    if (!trimmed || trimmed === s.source.trim()) {
+      delete state.editedSourceByStrategy[s.id];
+    } else {
+      state.editedSourceByStrategy[s.id] = src;
+    }
     scheduleRun();
-  }
-  ($("code-edit-toggle") as HTMLButtonElement).addEventListener("click", () => {
-    if (state.editing) exitEditMode();
-    else enterEditMode();
   });
-  ($("code-edit-run") as HTMLButtonElement).addEventListener("click", runEditedCode);
-  ($("code-edit-revert") as HTMLButtonElement).addEventListener("click", revertEdit);
-  ($("code-editor") as HTMLTextAreaElement).addEventListener("keydown", (ev) => {
+  codeEditor.addEventListener("keydown", (ev) => {
     if ((ev.metaKey || ev.ctrlKey) && ev.key === "Enter") {
+      // Force-commit + run immediately, bypass the debounce.
       ev.preventDefault();
-      runEditedCode();
+      if (codeEditTimer !== null) {
+        clearTimeout(codeEditTimer);
+        codeEditTimer = null;
+      }
+      const s = state.currentStrategy;
+      if (s) {
+        const src = codeEditor.value;
+        const trimmed = src.trim();
+        if (!trimmed || trimmed === s.source.trim()) {
+          delete state.editedSourceByStrategy[s.id];
+        } else {
+          state.editedSourceByStrategy[s.id] = src;
+        }
+        scheduleRun();
+      }
       return;
     }
-    if (ev.key === "Escape") {
-      ev.preventDefault();
-      exitEditMode();
-      return;
-    }
-    // Tab inserts indent rather than moving focus.
+    // Tab inserts a 4-space indent rather than moving focus out of the
+    // textarea — table stakes for an actually-usable code editor.
     if (ev.key === "Tab") {
       ev.preventDefault();
       const ta = ev.currentTarget as HTMLTextAreaElement;
@@ -849,6 +793,7 @@ result  = run_weight_backtest(dataset.prices, weights, config,
       const e = ta.selectionEnd;
       ta.value = ta.value.slice(0, s) + "    " + ta.value.slice(e);
       ta.selectionStart = ta.selectionEnd = s + 4;
+      scheduleEditedRun();
     }
   });
 

--- a/simulation/frontend/index.html
+++ b/simulation/frontend/index.html
@@ -5,10 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Strategy Simulator</title>
   <link rel="stylesheet" href="style.css" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" />
   <script src="https://cdn.plot.ly/plotly-2.35.2.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-python.min.js"></script>
 </head>
 <body>
   <div id="progress" class="progress idle"></div>
@@ -74,15 +71,8 @@
           <header class="panel-head">
             <h3>Live code</h3>
             <span class="panel-sub" id="code-path">strategies/research_strategies.py + backtester/research_backtester.py</span>
-            <div class="code-edit-toolbar">
-              <span class="code-edit-status" id="code-edit-status"></span>
-              <button type="button" id="code-edit-toggle" class="code-edit-btn">Edit</button>
-              <button type="button" id="code-edit-run" class="code-edit-btn primary" hidden>Run edited</button>
-              <button type="button" id="code-edit-revert" class="code-edit-btn" hidden>Revert</button>
-            </div>
           </header>
-          <pre class="code-block"><code id="code-live" class="language-python"></code></pre>
-          <textarea id="code-editor" class="code-editor" hidden spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off"></textarea>
+          <textarea id="code-editor" class="code-editor" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off"></textarea>
         </div>
 
         <div class="metrics-strip">

--- a/simulation/frontend/style.css
+++ b/simulation/frontend/style.css
@@ -604,50 +604,12 @@ a:hover { color: var(--amber-hot); text-decoration: underline; }
   margin: 0;
 }
 
-/* ---- Code panel ---- */
+/* ---- Code panel — single always-editable textarea ---- */
 .code-panel { min-height: 280px; }
-.code-edit-toolbar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-left: auto;
-}
-.code-edit-status {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--accent);
-  min-width: 0;
-  white-space: nowrap;
-}
-.code-edit-btn {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  background: transparent;
-  color: var(--text-2);
-  border: 1px solid var(--border);
-  padding: 4px 10px;
-  cursor: pointer;
-  border-radius: 2px;
-}
-.code-edit-btn:hover {
-  color: var(--accent);
-  border-color: var(--accent);
-}
-.code-edit-btn.primary {
-  color: var(--accent);
-  border-color: var(--accent);
-}
-.code-edit-btn.primary:hover {
-  background: rgba(var(--accent-rgb, 255, 176, 0), 0.08);
-}
-.code-edit-btn[disabled] { opacity: 0.4; cursor: not-allowed; }
 .code-editor {
   flex: 1 1 auto;
   width: 100%;
-  min-height: 320px;
-  max-height: 380px;
+  min-height: 360px;
   font-family: var(--font-mono);
   font-size: 14px;
   background: var(--bg);
@@ -661,57 +623,11 @@ a:hover { color: var(--amber-hot); text-decoration: underline; }
   white-space: pre;
   overflow: auto;
 }
-.code-editor:focus { outline: 0; box-shadow: inset 0 0 0 1px var(--accent); }
-.code-block {
-  margin: 0;
-  flex: 1 1 auto;
-  overflow: auto;
-  font-family: var(--font-mono) !important;
-  font-size: 14px !important;
-  background: var(--bg) !important;
-  padding: 14px 16px !important;
-  border: 0 !important;
-  border-radius: 0 !important;
-  line-height: 1.6;
-  tab-size: 4;
-  color: var(--text) !important;
-  text-shadow: none !important;
-  max-height: 380px;
+.code-editor:focus {
+  outline: 0;
+  box-shadow: inset 0 0 0 1px var(--amber);
 }
-.code-block code {
-  background: transparent !important;
-  font-family: inherit !important;
-  text-shadow: none !important;
-  color: inherit !important;
-}
-/* Override Prism Tomorrow tokens for the amber phosphor palette */
-.code-block .token.comment,
-.code-block .token.prolog,
-.code-block .token.doctype,
-.code-block .token.cdata { color: var(--text-3); font-style: italic; }
-.code-block .token.punctuation { color: var(--text-2); }
-.code-block .token.property,
-.code-block .token.tag,
-.code-block .token.boolean,
-.code-block .token.number,
-.code-block .token.constant,
-.code-block .token.symbol,
-.code-block .token.deleted { color: var(--amber); }
-.code-block .token.selector,
-.code-block .token.attr-name,
-.code-block .token.string,
-.code-block .token.char,
-.code-block .token.builtin,
-.code-block .token.inserted { color: var(--gain); }
-.code-block .token.atrule,
-.code-block .token.attr-value,
-.code-block .token.keyword { color: var(--ser-b); }
-.code-block .token.function,
-.code-block .token.class-name { color: var(--ser-a); font-weight: 500; }
-.code-block .token.regex,
-.code-block .token.important,
-.code-block .token.variable { color: var(--warn); }
-.code-block .token.operator { color: var(--text-2); background: transparent; }
+.code-editor::selection { background: var(--amber-soft); color: var(--text); }
 
 /* ---- Metrics strip — 4×2 grid: hero row glows big, secondary row tighter ---- */
 .metrics-strip {


### PR DESCRIPTION
Two changes:

- **Live code panel**: drop the Edit/Run/Revert toolbar. Textarea is always editable; debounced auto-run on input + immediate run on blur or ⌘Enter. Prism syntax-highlighting layer removed (no read-only display anymore).
- **Catalog**: trim to the 5 strategies the user wants in the deck, in the requested order: Value Composite, Simple Moving Average, Residual Momentum, Customer-Supplier Momentum, PEAD. Vanilla momentum and short-term reversal dropped from the catalog (classes still in research_strategies.py).