### PR TITLE
ops(fly): bump VM memory 1gb → 2gb

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -11,6 +11,6 @@ primary_region = "iad"
   min_machines_running = 1
 
 [[vm]]
-  memory = "1gb"
+  memory = "2gb"
   cpu_kind = "shared"
   cpus = 1


### PR DESCRIPTION
## Summary
- Bumps Fly VM memory 1GB → 2GB as a safety margin on top of the bounded sim cache + opt-in dataset cache. Worst-case Wharton runs can briefly spike past 1GB during weight construction; 2GB doubles headroom for ~+\$5/mo.

## Test plan
- [x] After merge: \`fly deploy\` re-rolls both machines on the new memory size.
- [x] Curl the live endpoint to confirm both replicas come back healthy.