### PR TITLE
fix(simulation): sticky params sidebar follows scroll

### DIFF
--- a/simulation/frontend/style.css
+++ b/simulation/frontend/style.css
@@ -272,11 +272,17 @@ a:hover { color: var(--amber-hot); text-decoration: underline; }
   align-items: start;
 }
 .sidebar {
-  /* Sticky sidebar was leaving a black void below the panel as the main
-     column scrolled past on tall pages. Static positioning lets the
-     sidebar scroll out of view naturally — params are at the top, results
-     are below. Cleaner for stage scrolling than a half-empty pinned column. */
+  /* Sticky so params stay visible while you scroll the chart and tweak
+     knobs live. align-self:start keeps the sidebar cell at its natural
+     height so the panel hugs its content (no black void below it).
+     max-height + overflow handles the rare case where the params rail
+     is taller than the viewport — it scrolls internally instead of
+     pushing the page. */
+  position: sticky;
+  top: 64px;
   align-self: start;
+  max-height: calc(100vh - 76px);
+  overflow-y: auto;
 }
 .app-split { align-items: start; }
 .sidebar .panel { border-color: var(--border); }


### PR DESCRIPTION
## Summary
- Re-enable \`position: sticky\` on the params sidebar so users can tweak knobs while watching the chart respond — no more scrolling back up.
- Two guards prevent the empty-void column we hit last time: \`align-self: start\` keeps the cell at natural height, and \`max-height + overflow-y\` makes the rail scroll internally if it ever exceeds the viewport.

## Test plan
- [x] Local check: scroll to y=1200, params still pinned at top-left, chart visible to the right.
- [x] No void below params even on the longest page (data inspector + audit + monthly returns + equity).