### PR TITLE
feat(simulation): restore Momentum + Mean Reversion as baseline tabs

### DIFF
--- a/simulation/backend/simulator.py
+++ b/simulation/backend/simulator.py
@@ -108,6 +108,34 @@ _SHORT_QUANTILE_OVERRIDE = {
 
 STRATEGIES = [
     {
+        "id": "momentum",
+        "cls": rs.CrossSectionalMomentumStrategy,
+        "cls_name": "CrossSectionalMomentumStrategy",
+        "label": "Momentum",
+        "formula": "score(t, i) = ln( P[t − skip, i] / P[t − lookback, i] )",
+        "summary": "Rank stocks by their return from (today − lookback_days) to (today − skip_days); long the top quantile, optionally short the bottom.",
+        "params": [
+            {"name": "lookback_days", "type": "int", "default": 126, "min": 21, "max": 504, "step": 21,
+             "help": "Return window (126 ≈ 6mo)."},
+            {"name": "skip_days",     "type": "int", "default": 21,  "min": 0,  "max": 63,  "step": 1,
+             "help": "Skip last N days to drop short-term reversal (21 ≈ 1mo)."},
+        ],
+        "engine_overrides": [_SHORT_QUANTILE_OVERRIDE],
+    },
+    {
+        "id": "mean_reversion",
+        "cls": rs.ShortTermReversalStrategy,
+        "cls_name": "ShortTermReversalStrategy",
+        "label": "Mean Reversion",
+        "formula": "score(t, i) = − ln( P[t, i] / P[t − lookback, i] )",
+        "summary": "Score stocks by their negated recent return; long the biggest recent losers, expecting a bounce.",
+        "params": [
+            {"name": "lookback_days", "type": "int", "default": 5, "min": 1, "max": 21, "step": 1,
+             "help": "Recent-return window; biggest losers rank highest."},
+        ],
+        "engine_overrides": [_SHORT_QUANTILE_OVERRIDE],
+    },
+    {
         "id": "value_composite",
         "cls": rs.ValueCompositeStrategy,
         "cls_name": "ValueCompositeStrategy",

--- a/simulation/frontend/app.ts
+++ b/simulation/frontend/app.ts
@@ -913,35 +913,6 @@ type StatusKind = "ready" | "loading" | "error" | "" | undefined;
       "bad",
       `turnover ${fmtX(o.turnover_annualized, 1)}/yr`,
     );
-    // Secondary row — Sortino, Calmar, Info Ratio, Hit Rate
-    setCard(
-      "m-sortino",
-      "m-sortino-sub",
-      fmtNum(m.sortino),
-      (m.sortino ?? 0) >= 1 ? "good" : ((m.sortino as number) < 0.3 ? "bad" : ""),
-      `downside-only Sharpe`,
-    );
-    setCard(
-      "m-calmar",
-      "m-calmar-sub",
-      fmtNum(m.calmar),
-      (m.calmar ?? 0) >= 0.5 ? "good" : ((m.calmar as number) < 0 ? "bad" : ""),
-      `ann ret / |max DD|`,
-    );
-    setCard(
-      "m-ir",
-      "m-ir-sub",
-      fmtNum(m.info_ratio),
-      (m.info_ratio ?? 0) >= 0.5 ? "good" : ((m.info_ratio as number) < 0 ? "bad" : ""),
-      `vs benchmark`,
-    );
-    setCard(
-      "m-hit",
-      "m-hit-sub",
-      fmtPct(m.hit_rate, 1),
-      (m.hit_rate ?? 0) >= 0.52 ? "good" : ((m.hit_rate as number) < 0.48 ? "bad" : ""),
-      `pos days / total`,
-    );
 
     lastRender.sim = data;
     const eqPal = chartPalette();
@@ -1900,10 +1871,6 @@ type StatusKind = "ready" | "loading" | "error" | "" | undefined;
       ["m-return", "m-return-sub"],
       ["m-dd", "m-dd-sub"],
       ["m-tcost", "m-tcost-sub"],
-      ["m-sortino", "m-sortino-sub"],
-      ["m-calmar", "m-calmar-sub"],
-      ["m-ir", "m-ir-sub"],
-      ["m-hit", "m-hit-sub"],
     ]) {
       const valueEl = $(valueId);
       valueEl.textContent = "—";

--- a/simulation/frontend/index.html
+++ b/simulation/frontend/index.html
@@ -80,10 +80,6 @@
           <div class="m-card"><div class="m-label">Ann. return</div><div class="m-value" id="m-return">—</div><div class="m-sub" id="m-return-sub"></div></div>
           <div class="m-card"><div class="m-label">Max drawdown</div><div class="m-value" id="m-dd">—</div><div class="m-sub" id="m-dd-sub"></div></div>
           <div class="m-card"><div class="m-label">T-cost drag / yr</div><div class="m-value" id="m-tcost">—</div><div class="m-sub" id="m-tcost-sub"></div></div>
-          <div class="m-card secondary"><div class="m-label">Sortino</div><div class="m-value" id="m-sortino">—</div><div class="m-sub" id="m-sortino-sub"></div></div>
-          <div class="m-card secondary"><div class="m-label">Calmar</div><div class="m-value" id="m-calmar">—</div><div class="m-sub" id="m-calmar-sub"></div></div>
-          <div class="m-card secondary"><div class="m-label">Info ratio</div><div class="m-value" id="m-ir">—</div><div class="m-sub" id="m-ir-sub"></div></div>
-          <div class="m-card secondary"><div class="m-label">Hit rate</div><div class="m-value" id="m-hit">—</div><div class="m-sub" id="m-hit-sub"></div></div>
         </div>
 
         <div class="panel">

--- a/simulation/frontend/style.css
+++ b/simulation/frontend/style.css
@@ -635,26 +635,20 @@ a:hover { color: var(--amber-hot); text-decoration: underline; }
 }
 .code-editor::selection { background: var(--amber-soft); color: var(--text); }
 
-/* ---- Metrics strip — 4×2 grid: hero row glows big, secondary row tighter ---- */
+/* ---- Metrics strip — single hero row of 4 ---- */
 .metrics-strip {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
-  grid-auto-rows: auto;
   gap: 0;
   background: var(--panel);
   border: 1px solid var(--border);
 }
 .m-card {
-  padding: 12px 22px 14px;
+  padding: 14px 22px 16px;
   border-right: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
   position: relative;
 }
-.m-card:nth-child(4n) { border-right: 0; }
-.m-card:nth-last-child(-n+4) { border-bottom: 0; }
-.m-card.secondary {
-  background: var(--panel-2);
-}
+.m-card:last-child { border-right: 0; }
 .m-card::before {
   content: "";
   position: absolute;
@@ -675,16 +669,16 @@ a:hover { color: var(--amber-hot); text-decoration: underline; }
 }
 .m-value {
   font-family: var(--font-mono);
-  font-size: 26px;
+  font-size: 42px;
   font-weight: 500;
   font-variant-numeric: tabular-nums;
   color: var(--amber);
   line-height: 1.0;
   letter-spacing: -0.02em;
-  text-shadow: 0 0 10px var(--amber-glow);
+  text-shadow: 0 0 14px var(--amber-glow);
 }
-.m-value.good { color: var(--gain); text-shadow: 0 0 10px rgba(105,201,122,0.5); }
-.m-value.bad  { color: var(--loss); text-shadow: 0 0 10px rgba(224,112,80,0.5); }
+.m-value.good { color: var(--gain); text-shadow: 0 0 14px rgba(105,201,122,0.5); }
+.m-value.bad  { color: var(--loss); text-shadow: 0 0 14px rgba(224,112,80,0.5); }
 .m-sub {
   font-family: var(--font-mono);
   font-size: 10.5px;


### PR DESCRIPTION
## Summary
Adds Momentum (12-1 cross-sectional) and Mean Reversion (short-term reversal) back to the catalog so prod has the two textbook baseline strategies followed by the five paper-backed custom strategies.

Final catalog order:
1. Momentum
2. Mean Reversion
3. Value Composite
4. Simple Moving Average
5. Residual Momentum
6. Customer-Supplier Momentum
7. Post-Earnings Announcement Drift

## Test plan
- [ ] After Fly redeploy, /api/catalog returns all 7 strategies
- [ ] Momentum sim runs without OOM (2GB VM)
- [ ] Mean Reversion sim runs without OOM