### PR TITLE
ops(fly): cpus 1 → 2 so 4gb memory fits

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -13,4 +13,4 @@ primary_region = "iad"
 [[vm]]
   memory = "4gb"
   cpu_kind = "shared"
-  cpus = 1
+  cpus = 2


### PR DESCRIPTION
shared-cpu-1x preset caps at 2GB. Step up to shared-cpu-2x to allow the 4gb memory bump.