### PR TITLE
ops(fly): 8gb on shared-cpu-4x for wharton

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -11,6 +11,6 @@ primary_region = "iad"
   min_machines_running = 1
 
 [[vm]]
-  memory = "4gb"
+  memory = "8gb"
   cpu_kind = "shared"
-  cpus = 2
+  cpus = 4


### PR DESCRIPTION
Wharton + simulate peaks at ~3.8GB on a 4GB VM. 8GB on cpu-4x gives reliable headroom.