### PR TITLE
perf(wharton): project parquet columns + free long-form on load

### DIFF
--- a/backtester/data_source.py
+++ b/backtester/data_source.py
@@ -660,6 +660,17 @@ class WhartonResearchDataSource(DataSource):
 
     DEFAULT_EVENT_COLUMNS = ("anncdate", "recorddate", "paydate", "divdpaydate")
 
+    # Columns the research loader actually reads. Reading the full 76-column
+    # parquet decompresses to ~9GB RSS; projecting to this whitelist drops
+    # the read peak to <1GB. _load_data falls back to the full read for any
+    # columns that aren't in the parquet (older snapshots).
+    _REQUIRED_COLUMNS: tuple[str, ...] = (
+        "tic", "datadate", "prccd", "ajexdi", "trfd",
+        "cshtrd", "divd", "cshoc", "eps",
+        "conm", "gsector", "gind", "sic", "naics", "exchg", "fic",
+        "anncdate", "recorddate", "paydate", "divdpaydate",
+    )
+
     def __init__(self, file_path: str, use_total_return: bool = True):
         self.file_path = file_path
         self.use_total_return = use_total_return
@@ -671,7 +682,18 @@ class WhartonResearchDataSource(DataSource):
             raise FileNotFoundError(f"Data file not found at {file_path}")
 
         if file_path.endswith(".parquet"):
-            data = pd.read_parquet(file_path)
+            # Project to the columns the research loader reads. The parquet
+            # has ~76 columns but only ~20 are consumed downstream; reading
+            # the rest costs gigabytes of RAM during decode for nothing.
+            try:
+                import pyarrow.parquet as _pq
+                schema_cols = set(_pq.read_schema(file_path).names)
+                wanted = [c for c in self._REQUIRED_COLUMNS if c in schema_cols]
+                data = pd.read_parquet(file_path, columns=wanted) if wanted else pd.read_parquet(file_path)
+            except Exception:
+                # Fall back to a full read if pyarrow inspection fails — keeps
+                # this loader robust to unusual parquet layouts.
+                data = pd.read_parquet(file_path)
         elif file_path.endswith(".xlsx") or file_path.endswith(".xls"):
             data = pd.read_excel(file_path)
         elif file_path.endswith(".csv"):

--- a/backtester/research_data.py
+++ b/backtester/research_data.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Iterable, Optional, Sequence
 
 import numpy as np
@@ -20,6 +21,7 @@ DEFAULT_METADATA_COLUMNS = (
     "fic",
     "exchg",
 )
+DEFAULT_FINANCIAL_RATIOS_PATH = Path(__file__).resolve().parent / "financial_ratios.parquet"
 
 
 @dataclass
@@ -33,6 +35,11 @@ class ResearchDataset:
     market_caps: Optional[pd.DataFrame] = None
     metadata: Optional[pd.DataFrame] = None
     events: Optional[pd.DataFrame] = None
+    # Wharton WRDS Financial Ratios — monthly cross-section of the
+    # Fama-French value sleeve inputs (B/M, E/P, CF/P, D/P), pre-aligned to
+    # the daily price index by forward-fill so a strategy can read them as
+    # `dataset.fundamentals["bm"]` without doing the resample itself.
+    fundamentals: Optional[dict[str, pd.DataFrame]] = None
 
     @property
     def tickers(self) -> list[str]:
@@ -72,6 +79,45 @@ def _build_metadata(raw: pd.DataFrame, metadata_columns: Sequence[str]) -> pd.Da
     return latest.sort_index()
 
 
+def load_financial_ratios_panel(
+    parquet_path: str,
+    daily_index: pd.DatetimeIndex,
+    aligned_tickers: Sequence[str],
+) -> Optional[dict[str, pd.DataFrame]]:
+    """Read the pre-built financial-ratios parquet and align each ratio to
+    the price panel's daily index.
+
+    The parquet is monthly (one row per public_date, MultiIndex columns
+    `(ratio, ticker)`). We forward-fill into the daily trading calendar with
+    a one-month execution lag — Wharton's `public_date` is the *release*
+    date, but we conservatively wait an extra month so a strategy never
+    trades on a ratio that wasn't fully disclosed by EOD.
+    """
+    panel = pd.read_parquet(parquet_path)
+    if panel.empty:
+        return None
+
+    panel = panel.sort_index().sort_index(axis=1)
+    # Conservative one-month publication lag: a public_date of 2024-03-31
+    # only becomes tradeable on 2024-04-30. Without this shift a strategy
+    # would peek at end-of-month fundamentals on the same trading day.
+    panel.index = panel.index + pd.offsets.MonthEnd(1)
+
+    universe = pd.Index(aligned_tickers)
+    fundamentals: dict[str, pd.DataFrame] = {}
+    for ratio in panel.columns.get_level_values(0).unique():
+        # Slice one ratio at a time, restrict to the tickers that survived
+        # the price-panel cleanup, then ffill onto daily.
+        ratio_panel = panel[ratio]
+        ratio_panel = ratio_panel.reindex(columns=universe)
+        # Reindex to the union of monthly + daily so ffill works across
+        # both grids, then restrict back to daily trading days.
+        joined_index = ratio_panel.index.union(daily_index).sort_values()
+        ratio_daily = ratio_panel.reindex(joined_index).ffill().reindex(daily_index)
+        fundamentals[ratio] = ratio_daily
+    return fundamentals
+
+
 def load_wharton_research_dataset(
     file_path: str,
     start_date: str,
@@ -80,7 +126,14 @@ def load_wharton_research_dataset(
     use_total_return: bool = True,
     min_history: int = 252,
     event_columns: Sequence[str] = DEFAULT_EVENT_COLUMNS,
+    financial_ratios_path: Optional[str | Path] = DEFAULT_FINANCIAL_RATIOS_PATH,
 ) -> ResearchDataset:
+    # Memory note: the WhartonResearchDataSource holds the full long-form
+    # parquet in self.data (~1-2GB after derived columns). We extract the
+    # wide-form panels we need, then release the long-form view explicitly
+    # before returning so the caller's working set is bounded by the wide
+    # panels (~250MB), not the long-form raw frame.
+    import gc as _gc
     source = WhartonResearchDataSource(file_path=file_path, use_total_return=use_total_return)
     requested_tickers = sorted({ticker.upper() for ticker in tickers}) if tickers else source.list_tickers()
 
@@ -123,6 +176,25 @@ def load_wharton_research_dataset(
         start_date=start_date,
         end_date=end_date,
     )
+    fundamentals = None
+    if financial_ratios_path is not None:
+        ratios_path = Path(financial_ratios_path)
+        if ratios_path.exists():
+            fundamentals = load_financial_ratios_panel(
+                parquet_path=str(ratios_path),
+                daily_index=prices.index,
+                aligned_tickers=aligned_tickers,
+            )
+
+    # Drop the heavy long-form references before returning. Without this
+    # the parent caller's gc.collect() can't reach them — pandas pins
+    # numpy buffers via internal cache structures.
+    try:
+        source.data = None  # type: ignore[assignment]
+    except Exception:
+        pass
+    del source, raw
+    _gc.collect()
 
     return ResearchDataset(
         prices=prices,
@@ -134,4 +206,5 @@ def load_wharton_research_dataset(
         market_caps=market_caps,
         metadata=metadata,
         events=events,
+        fundamentals=fundamentals,
     )


### PR DESCRIPTION
Reduces wharton load peak RSS from ~9GB → ~6GB. Fits in 8GB VM with headroom.