### PR TITLE
docs: refresh + research scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,10 @@ sp500_universe.pkl
 .claude/
 data_quality_materials/
 .gstack/
+
+# Slide / research output dirs — generated artifacts, not source
+slide_assets/
+slide_ready_signal_graphs/
+five_signal_results/
+all_alpha_results/
+*.pdf

--- a/README.md
+++ b/README.md
@@ -1,24 +1,64 @@
 # Millennium Quantitative Research Playground
 
-A backtesting framework for long-only cross-sectional equity factor strategies
-on a local Wharton / Compustat daily dataset. Includes a prop-shop grade alpha
-research toolkit (IC, quantile spread, factor models, walk-forward validation,
-HRP portfolio optimization, stress testing, tearsheets).
+A two-track quantitative research project:
 
-The headline deliverable is `run_book.py` — a 5-sleeve alpha book that combines
-vol-managed equity, trend-filtered equity, and three long-only factor sleeves
-(Momentum, Low Volatility, Small-Cap Tilt) via Hierarchical Risk Parity.
+1. **Live strategy simulator** — a deployed web app where you can pick a
+   strategy, tune parameters, edit the engine code in the browser, and watch
+   the equity curve update against either the live yfinance S&P 500 cache
+   or a Wharton WRDS panel.
+2. **Research toolkit** — long-only cross-sectional equity factor strategies
+   on a local Wharton / Compustat daily dataset. Alpha research (IC, quantile
+   spread, factor models, walk-forward validation), HRP portfolio
+   optimization, stress testing, tearsheets.
 
-**Best result on Wharton 2000-2025 (165 SP500 names, 10bps t-cost, no lookahead):**
+## Live simulator
+
+- Frontend: [cds-millennium-backtester.vercel.app](https://cds-millennium-backtester.vercel.app/)
+- Backend: [cds-millennium-backtester.fly.dev](https://cds-millennium-backtester.fly.dev/api/status)
+
+Three strategies in the catalog today:
+
+| ID | Strategy | Source class |
+|----|----------|--------------|
+| `momentum` | Cross-sectional momentum (12-1) | `CrossSectionalMomentumStrategy` |
+| `mean_reversion` | Short-term reversal | `ShortTermReversalStrategy` |
+| `value_composite` | Fama-French value blend (div yield + E/P + size) | `ValueCompositeStrategy` |
+
+Two data sources, switchable from the topbar:
+
+- `yfinance` — today's ~503 S&P 500 constituents, refreshed daily via
+  `run_sp500_fetch.py` and persisted to `data_cache/yfinance/`.
+- `wharton` — the static Wharton WRDS panel
+  (`backtester/WhartonDataSource4.parquet`, ~830 tickers across the historic
+  S&P 500 membership). Survivorship-bias-aware.
+
+Headline features:
+
+- **Live editable engine code panel.** Edit the strategy's Python source in
+  the browser and the backend re-compiles + runs your version on the same
+  data + engine knobs.
+- **Per-tab pinning.** Run a config, hit Pin, change params, and the old
+  curve stays on the chart for comparison.
+- **Survivorship audit panel** quantifies the upward bias from running on
+  today's index members.
+- **Universe filter** — restrict the run to a specific ticker subset (Apply
+  / Exclude / Reset).
+
+## Research toolkit (offline)
+
+The research-grade alpha book lives in `run_book.py`: a 5-sleeve combination
+of vol-managed equity, trend-filtered equity, and three long-only factor
+sleeves (Momentum, Low Volatility, Small-Cap Tilt) via Hierarchical Risk
+Parity.
+
+Best result on Wharton 2000-2025 (165 SP500 names, 10bps t-cost, no
+lookahead):
 
 | Strategy | Ann Return | Sharpe | Sortino | Max DD |
 |---|---|---|---|---|
 | Equal-Weight Benchmark | +13.63% | 0.760 | 0.973 | -50.88% |
 | Small-Cap Tilt + Trend | +14.57% | **1.095** | 1.341 | -33.92% |
 | **Combined Book (HRP)** | +10.34% | **1.003** | **1.253** | **-23.80%** |
-
-See [SESSION_NOTES.md](SESSION_NOTES.md) for the full session arc, mistakes
-made, and notes for improvement.
 
 ## Installation
 
@@ -29,12 +69,38 @@ python3 -m venv .venv
 .venv/bin/pip install -r requirements.txt
 ```
 
-Data file: `backtester/WhartonDataSource.parquet` is included (19MB, 165
-SP500 names, 2000-2025).
+Data files:
 
-## Quick Start
+- `backtester/WhartonDataSource4.parquet` — the simulator's Wharton source.
+- `backtester/financial_ratios.parquet` — Wharton WRDS Financial Ratios
+  panel used by `ValueCompositeStrategy`.
+- `backtester/surprise earning.csv` — SUE event panel (loaded lazily by the
+  PEAD strategy when present).
 
-### Run the alpha book
+## Quick start
+
+### Run the live simulator locally
+
+```sh
+.venv/bin/python -m simulation.backend.server --host 127.0.0.1 --port 8765
+# open simulation/frontend/index.html — or set up the dev workflow:
+cd simulation/frontend && npm install && npm run watch
+```
+
+The frontend is a single TypeScript file that compiles to `app.js` and gets
+served by the Python backend.
+
+For snappy yfinance ↔ wharton toggling locally:
+
+```sh
+MILLENNIUM_DATASET_CACHE=1 .venv/bin/python -m simulation.backend.server
+```
+
+This holds both panels in memory so a return trip is a pointer-swap. Off by
+default in production (the Fly VM only loads one source at a time and frees
+the previous panel before reading the new one).
+
+### Run the offline alpha book
 
 ```sh
 .venv/bin/python run_book.py
@@ -42,8 +108,7 @@ SP500 names, 2000-2025).
 
 Uses the default window (2000-01-01 to 2025-01-01), 16% target vol, 200-day
 trend filter, long-only top 20% selection sleeves. Outputs go to
-`book_results/` including cumulative returns plots, per-sleeve tearsheets,
-stress test CSV, and a summary table.
+`book_results/`.
 
 Customize:
 ```sh
@@ -62,23 +127,26 @@ Customize:
   --combine-method hrp
 ```
 
-This runs the `build_default_strategy_suite()` slate (Small-Cap Tilt, Value
-Composite, Earnings Revision, Sector-Neutral Dividend Yield, Cross-Sectional
-Momentum, Low Volatility) through the weight-based research backtester with
-lag tables, event studies, tearsheets, stress regimes, Monte Carlo CIs, and
-a combined-book output.
+This runs the `build_default_strategy_suite()` slate through the
+weight-based research backtester with lag tables, event studies,
+tearsheets, stress regimes, Monte Carlo CIs, and a combined-book output.
 
 ## Architecture
 
-See [guide.md](guide.md) for the current project structure and module index.
+See [guide.md](guide.md) for the current project structure and module
+index. Research workflow detail: [PROJECT_PLAN.md](PROJECT_PLAN.md).
+Presentation notes: [PRESENTATION_NOTES.md](PRESENTATION_NOTES.md).
+Session notes: [SESSION_NOTES.md](SESSION_NOTES.md).
 
-Research workflow detail: [PROJECT_PLAN.md](PROJECT_PLAN.md)
+## Deploy
 
-Presentation notes: [PRESENTATION_NOTES.md](PRESENTATION_NOTES.md)
+- **Frontend (Vercel)** — auto-deploys from `main`. Static TypeScript build,
+  rewrites `/api/*` to the Fly backend (see `simulation/frontend/vercel.json`).
+- **Backend (Fly)** — `fly deploy --remote-only`. The VM runs
+  `simulation/backend/server.py` on shared-cpu-4x with 8GB memory (sized for
+  the wharton load + simulate peak; see `fly.toml`).
 
-Session notes, mistakes, improvements: [SESSION_NOTES.md](SESSION_NOTES.md)
-
-## Running Tests
+## Running tests
 
 ```sh
 .venv/bin/python -m unittest discover -s unit_tests

--- a/backtester/ensemble.py
+++ b/backtester/ensemble.py
@@ -140,13 +140,52 @@ def max_diversification_weights(
 # ---------------------------------------------------------------------------
 # Model weight computation (anti-lookahead dispatcher)
 # ---------------------------------------------------------------------------
+def _cap_and_renormalize(weights: pd.Series, max_weight: float) -> pd.Series:
+    """Cap any single sleeve's weight at `max_weight` and water-fill the
+    excess equally across the uncapped sleeves. Equal redistribution avoids
+    the oscillation you get with proportional redistribution when only one
+    or two free sleeves carry non-zero weight (proportional dumps all the
+    excess on the largest, which then exceeds the cap on the next pass).
+    """
+    w = weights.astype(float).copy()
+    n = len(w)
+    if n == 0 or w.sum() <= 0:
+        return w
+    # Infeasible cap: max_weight * n < 1 means even all-at-cap doesn't fill
+    # the budget — fall back to uniform.
+    if max_weight * n < 1.0 - 1e-9:
+        return pd.Series(1.0 / n, index=w.index)
+    w = w / w.sum()
+    capped = pd.Series(False, index=w.index)
+    for _ in range(n + 1):
+        over = (w > max_weight + 1e-12) & (~capped)
+        if not over.any():
+            break
+        # Cap any newly-over sleeves and lock them in.
+        excess = (w[over] - max_weight).sum()
+        w[over] = max_weight
+        capped = capped | over
+        free = ~capped
+        if not free.any():
+            break
+        # Equal water-fill across uncapped sleeves.
+        w[free] = w[free] + excess / int(free.sum())
+    return w
+
+
 def compute_model_weights(
     sleeve_returns: pd.DataFrame,
     model: ModelSpec,
     as_of_date: pd.Timestamp,
     min_obs: int = 126,
+    max_sleeve_weight: float = 0.20,
 ) -> pd.Series:
-    """Compute sleeve weights for one model using only data up to as_of_date."""
+    """Compute sleeve weights for one model using only data up to as_of_date.
+
+    `max_sleeve_weight` caps any single sleeve's allocation. With ~10 sleeves
+    the equal-weight baseline is 10%, so a 20% cap allows real conviction
+    while preventing structurally-low-vol sleeves from running away.
+    """
     history = sleeve_returns.loc[:as_of_date]
     if len(history) < min_obs:
         return equal_weight(sleeve_returns.columns)
@@ -156,21 +195,20 @@ def compute_model_weights(
 
     if model.method == "inverse_vol":
         vols = history.std()
-        return inverse_volatility_weight(vols)
-
-    if model.method == "hrp":
-        return hierarchical_risk_parity(history)
-
-    cov = shrinkage_covariance(history)
-
-    if model.method == "risk_parity":
-        return risk_parity_weights(cov)
-    if model.method == "min_variance":
-        return minimum_variance_weights(cov)
-    if model.method == "max_diversification":
-        return max_diversification_weights(cov)
-
-    raise ValueError(f"Unknown method: {model.method}")
+        weights = inverse_volatility_weight(vols)
+    elif model.method == "hrp":
+        weights = hierarchical_risk_parity(history)
+    else:
+        cov = shrinkage_covariance(history)
+        if model.method == "risk_parity":
+            weights = risk_parity_weights(cov)
+        elif model.method == "min_variance":
+            weights = minimum_variance_weights(cov)
+        elif model.method == "max_diversification":
+            weights = max_diversification_weights(cov)
+        else:
+            raise ValueError(f"Unknown method: {model.method}")
+    return _cap_and_renormalize(weights, max_sleeve_weight)
 
 
 # ---------------------------------------------------------------------------

--- a/guide.md
+++ b/guide.md
@@ -4,14 +4,28 @@
 
 ```
 millennium-data-quality-25-26/
-├── run_book.py                           # THE deliverable — 5-sleeve alpha book
+├── run_book.py                           # 5-sleeve alpha book (research deliverable)
 ├── research_main.py                      # Research pipeline CLI entry point
 ├── PROJECT_PLAN.md                       # Research workflow / presentation plan
 ├── PRESENTATION_NOTES.md                 # Notes for the research deck
-├── SESSION_NOTES.md                      # This session's arc, mistakes, improvements
+├── SESSION_NOTES.md                      # Session arc, mistakes, improvements
+├── fly.toml                              # Fly.io VM config for the backend
+├── Dockerfile                            # Backend image (Python 3.11)
+│
+├── simulation/                           # The live web simulator
+│   ├── backend/
+│   │   ├── server.py                     # ThreadingHTTPServer — /api/{status,catalog,simulate,…}
+│   │   └── simulator.py                  # STRATEGIES catalog, warmup + cache, run_simulation
+│   └── frontend/
+│       ├── index.html                    # Single-page shell
+│       ├── app.ts → app.js               # TypeScript app — params, plotly chart, code editor
+│       ├── style.css                     # Amber phosphor terminal aesthetic
+│       └── vercel.json                   # Static build + /api proxy to Fly
 │
 ├── backtester/
-│   ├── WhartonDataSource.parquet         # Local 165-ticker SP500 daily data (2000-2025)
+│   ├── WhartonDataSource4.parquet        # Live simulator's wharton source (~830 tickers)
+│   ├── financial_ratios.parquet          # WRDS ratios panel — used by Value Composite
+│   ├── surprise earning.csv              # SUE event panel — read lazily by PEAD
 │   ├── data_source.py                    # WhartonDataSource, YahooFinanceDataSource, PickleDataSource
 │   ├── research_data.py                  # ResearchDataset loader (prices, returns, volumes, events)
 │   ├── research_backtester.py            # Weight-based backtester, lag tables, event studies
@@ -36,11 +50,14 @@ millennium-data-quality-25-26/
 │   └── attribution.py                    # Factor attribution, Brinson, contribution ranking
 │
 ├── strategies/
-│   └── research_strategies.py            # 6 SignalStrategy classes for the research framework
-│                                         # (Small-Cap Tilt, Value Composite, Earnings Revision,
-│                                         #  Sector-Neutral Dividend Yield, Cross-Sectional
-│                                         #  Momentum, Low Volatility)
+│   └── research_strategies.py            # SignalStrategy classes used by both tracks:
+│                                         #   live simulator → CrossSectionalMomentumStrategy,
+│                                         #   ShortTermReversalStrategy, ValueCompositeStrategy
+│                                         #   (catalog wired in simulation/backend/simulator.py)
+│                                         #   research/run_book → also pulls Small-Cap Tilt,
+│                                         #   Sector-Neutral Dividend Yield, Low Volatility
 │
+
 ├── unit_tests/                           # 88 tests covering every module above
 │   ├── test_alpha_research.py
 │   ├── test_execution.py
@@ -62,6 +79,33 @@ millennium-data-quality-25-26/
 ```
 
 ## Architecture Overview
+
+### Live simulator — `simulation/`
+Two surfaces, one engine.
+
+`simulation/backend/server.py` is a ThreadingHTTPServer with five JSON
+endpoints: `/api/status`, `/api/catalog`, `/api/simulate`,
+`/api/universe/add`, and `/api/data*`. It serves the frontend statically
+when run locally and proxies through Vercel rewrites in production.
+
+`simulation/backend/simulator.py` holds the catalog (`STRATEGIES = […]`)
+that maps each user-visible strategy to a `SignalStrategy` subclass plus
+its tunable params and engine overrides. `warmup()` loads either the
+yfinance cache or the wharton parquet into a `ResearchDataset` and caches
+that in-process. The same `build_target_weights` + `run_weight_backtest`
+that the research track uses is what runs each request.
+
+The frontend (`simulation/frontend/app.ts`) is a single-file TypeScript
+app — no framework. Plotly for the charts, Prism for code highlighting,
+hand-rolled state machine for params. The "Engine code" panel is a
+`<textarea>` that lets the user edit the strategy class source live; the
+backend (`_compile_strategy_override`) execs the user's source in a
+sandbox namespace seeded with `pd`, `np`, `SignalStrategy`, and
+`ResearchDataset`, finds the new subclass, and runs it.
+
+Production runs on a Fly.io VM (shared-cpu-4x, 8GB) — wharton's
+parquet decode peaks at ~6GB during load. The frontend ships via
+Vercel from `main`.
 
 ### Data layer — `backtester/data_source.py` + `backtester/research_data.py`
 `WhartonDataSource` loads the local parquet, computes split-adjusted and
@@ -105,12 +149,26 @@ attribution, historical regime replays against 10 named drawdown windows
 2. Add a new class inheriting from `SignalStrategy` (see existing examples)
 3. Implement `generate_scores(self, dataset: ResearchDataset) -> pd.DataFrame`
 4. Optionally override `normalize_scores` for sector-neutral handling
-5. Either include it in `build_default_strategy_suite()` for the research CLI
-   or import it directly in `run_book.py` as a new sleeve
 
 The strategy contract is simple: return a DataFrame with the same shape as
-`dataset.prices` where each cell is the cross-sectional score for that ticker
-on that date. Higher = more desirable.
+`dataset.prices` where each cell is the cross-sectional score for that
+ticker on that date. Higher = more desirable.
+
+### Wiring it into the research pipeline
+
+Include it in `build_default_strategy_suite()` for the research CLI, or
+import it directly in `run_book.py` as a new sleeve.
+
+### Wiring it into the live simulator
+
+Edit `simulation/backend/simulator.py` and append an entry to the
+`STRATEGIES` list with the strategy id, class, label, summary, formula,
+tunable params, and engine overrides. The frontend dynamically renders
+whatever the catalog returns — no frontend changes needed.
+
+For one-off experimentation, you can also edit any existing strategy's
+class source in the simulator's "Engine code" panel and click Run; the
+edited class runs through the same backtest engine.
 
 ## Running the Alpha Book
 

--- a/run_all_alphas.py
+++ b/run_all_alphas.py
@@ -1,0 +1,724 @@
+"""All-alpha combined book with no full-sample Sharpe picking.
+
+This runner builds every implemented alpha sleeve under one shared, explicit
+backtest recipe, then combines the sleeves with an expanding-window ensemble.
+
+No-hacking rules:
+  - Same stock-selection config for every sleeve.
+  - One-day execution lag.
+  - 10 bps transaction costs at the stock sleeve and allocation layers.
+  - Optional trend risk overlay uses only yesterday's market level vs SMA.
+  - Combination weights are estimated with data available up to each rebalance.
+  - Final portfolio is the equal meta-blend of all combination models, not the
+    best full-sample model.
+"""
+from __future__ import annotations
+
+import argparse
+import warnings
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mtick
+import numpy as np
+import pandas as pd
+
+from backtester.ensemble import DEFAULT_MODELS, EnsembleConfig, run_expanding_window_ensemble
+from backtester.research_backtester import BacktestConfig, build_target_weights, run_weight_backtest
+from backtester.research_data import load_financial_ratios_panel, load_wharton_research_dataset
+from backtester.stress_test import regime_report, worst_drawdowns
+from backtester.tearsheet import generate_tearsheet
+from run_book import annualize, trend_filtered_returns
+from strategies.research_strategies import (
+    CrossSectionalMomentumStrategy,
+    CustomerSupplierMomentumStrategy,
+    EarningsRevisionStrategy,
+    LowVolatilityStrategy,
+    MLRidgeStrategy,
+    MovingAverageCrossoverStrategy,
+    PEADStrategy,
+    ResidualMomentumStrategy,
+    SectorNeutralDividendYieldStrategy,
+    ShortTermReversalStrategy,
+    SignalStrategy,
+    SmallCapTiltStrategy,
+    _cross_sectional_zscore,
+)
+
+
+warnings.filterwarnings("ignore", category=FutureWarning)
+warnings.filterwarnings("ignore", category=RuntimeWarning)
+
+
+class DeckValueCompositeStrategy(SignalStrategy):
+    name = "Value Composite"
+    motivation = "Blend dividend yield, earnings yield, and size into the value score shown in the deck."
+    economic_rationale = "Cheap names with cash-flow support can outperform expensive peers over long horizons."
+    why_it_works = "The blend avoids relying on one noisy accounting field and keeps turnover low."
+    why_it_fails = "Value can underperform during growth-led regimes or when cheap names are cheap for distress reasons."
+
+    def __init__(self, trailing_days: int = 252):
+        self.trailing_days = trailing_days
+
+    def generate_scores(self, dataset) -> pd.DataFrame:
+        if dataset.dividends is None or dataset.dividends.empty or dataset.eps is None or dataset.eps.empty:
+            return pd.DataFrame(index=dataset.prices.index, columns=dataset.prices.columns, dtype=float)
+
+        trailing_dividends = dataset.dividends.rolling(
+            self.trailing_days,
+            min_periods=max(self.trailing_days // 4, 1),
+        ).sum()
+        dividend_yield = trailing_dividends.div(dataset.prices.replace(0, np.nan))
+        earnings_yield = dataset.eps.div(dataset.prices.replace(0, np.nan))
+
+        if dataset.market_caps is None or dataset.market_caps.empty:
+            size_component = pd.DataFrame(0.0, index=dataset.prices.index, columns=dataset.prices.columns)
+        else:
+            size_component = -np.log(dataset.market_caps.replace(0, np.nan))
+
+        z_frames = [
+            _cross_sectional_zscore(dividend_yield),
+            _cross_sectional_zscore(earnings_yield),
+            _cross_sectional_zscore(size_component),
+        ]
+        stacked = np.stack([frame.to_numpy(dtype=float) for frame in z_frames], axis=0)
+        summed = np.nansum(stacked, axis=0)
+        all_nan = np.isnan(stacked).all(axis=0)
+        summed[all_nan] = np.nan
+        return pd.DataFrame(summed, index=dataset.prices.index, columns=dataset.prices.columns)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the no-hacking all-alpha combined book.")
+    parser.add_argument("--start", default="2000-01-01")
+    parser.add_argument("--end", default="2025-01-01")
+    parser.add_argument("--output-dir", default="all_alpha_results")
+    parser.add_argument("--data", default="backtester/WhartonDataSource.parquet")
+    parser.add_argument("--financial-ratios", default="backtester/financial_ratios.parquet")
+    parser.add_argument("--tcost-bps", type=float, default=10.0)
+    parser.add_argument("--overlay-tcost-bps", type=float, default=2.0)
+    parser.add_argument("--long-quantile", type=float, default=0.20)
+    parser.add_argument("--max-position-weight", type=float, default=0.08)
+    parser.add_argument("--composite-quantile", type=float, default=0.05)
+    parser.add_argument("--composite-max-position-weight", type=float, default=0.20)
+    parser.add_argument("--min-names", type=int, default=5)
+    parser.add_argument("--rf-annual", type=float, default=0.04)
+    parser.add_argument("--sma-window", type=int, default=200)
+    parser.add_argument("--burn-in-years", type=float, default=2.0)
+    parser.add_argument("--no-trend-filter", action="store_true")
+    parser.add_argument("--regime-tilt", action="store_true")
+    parser.add_argument("--skip-ml", action="store_true")
+    return parser.parse_args()
+
+
+def build_alpha_catalog(include_ml: bool = True) -> list:
+    # Deck-locked five-sleeve catalog. The wider library still lives in
+    # `strategies.research_strategies` for the simulator UI; this runner
+    # mirrors the slides exactly.
+    return [
+        DeckValueCompositeStrategy(),
+        MovingAverageCrossoverStrategy(short_window=50, long_window=200),
+        ResidualMomentumStrategy(beta_window=252, lookback_days=126, skip_days=21),
+        CustomerSupplierMomentumStrategy(customer_lookback_days=42, min_customers=1),
+        PEADStrategy(holding_days=60),
+    ]
+
+
+def format_pct(x: float) -> str:
+    if pd.isna(x):
+        return "--"
+    return f"{x:.2%}"
+
+
+def metric_row(name: str, returns: pd.Series) -> dict:
+    metrics = annualize(returns)
+    metrics["strategy"] = name
+    return metrics
+
+
+def safe_file_stem(name: str) -> str:
+    return (
+        name.replace("/", "_")
+        .replace(" ", "_")
+        .replace("-", "_")
+        .replace("(", "")
+        .replace(")", "")
+    )
+
+
+def run_alpha_sleeves(args: argparse.Namespace, dataset, output_dir: Path) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, pd.DataFrame]]:
+    base_config = BacktestConfig(
+        rebalance_frequency="ME",
+        signal_lag=1,
+        transaction_cost_bps=args.tcost_bps,
+        long_quantile=args.long_quantile,
+        short_quantile=0.0,
+        leverage=1.0,
+        max_position_weight=args.max_position_weight,
+        construction_method="inverse_vol",
+        long_only=True,
+        min_names=args.min_names,
+    )
+
+    benchmark = dataset.benchmark_returns.reindex(dataset.prices.index).fillna(0.0)
+    benchmark_level = (1.0 + benchmark).cumprod()
+
+    final_returns: dict[str, pd.Series] = {}
+    raw_returns: dict[str, pd.Series] = {}
+    score_frames: dict[str, pd.DataFrame] = {}
+    summary_rows: list[dict] = []
+
+    for strategy in build_alpha_catalog(include_ml=not args.skip_ml):
+        print(f"\nRunning alpha sleeve: {strategy.name}")
+        try:
+            scores = strategy.generate(dataset).scores
+            score_frames[strategy.name] = scores.reindex_like(dataset.returns)
+            score_counts = scores.notna().sum(axis=1)
+            avg_score_coverage = float(score_counts.mean())
+            max_score_coverage = int(score_counts.max()) if len(score_counts) else 0
+
+            weights = build_target_weights(scores, dataset.returns, base_config)
+            result = run_weight_backtest(
+                prices=dataset.prices,
+                target_weights=weights,
+                config=base_config,
+                benchmark_returns=benchmark,
+                strategy_name=strategy.name,
+            )
+            raw = result.net_returns.reindex(dataset.prices.index).fillna(0.0)
+
+            if args.no_trend_filter:
+                final = raw
+            else:
+                final, _ = trend_filtered_returns(
+                    benchmark_level,
+                    raw,
+                    risk_free_annual=args.rf_annual,
+                    sma_window=args.sma_window,
+                    transaction_cost_bps=args.overlay_tcost_bps,
+                )
+
+            raw_returns[strategy.name] = raw
+            final_returns[strategy.name] = final.reindex(dataset.prices.index).fillna(0.0)
+
+            raw_m = annualize(raw)
+            final_m = annualize(final_returns[strategy.name])
+            active_rebalances = int((weights.abs().sum(axis=1) > 0).sum())
+            active_days = int((weights.abs().sum(axis=1) > 0).sum())
+            included = final_returns[strategy.name].std(ddof=0) > 1e-10 and active_days > 0
+
+            summary_rows.append(
+                {
+                    "strategy": strategy.name,
+                    "included": included,
+                    "avg_score_coverage": avg_score_coverage,
+                    "max_score_coverage": max_score_coverage,
+                    "active_days": active_days,
+                    "active_rebalance_rows": active_rebalances,
+                    "raw_ann_return": raw_m.get("Annualized Return", np.nan),
+                    "raw_sharpe": raw_m.get("Sharpe Ratio", np.nan),
+                    "raw_max_drawdown": raw_m.get("Max Drawdown", np.nan),
+                    "final_ann_return": final_m.get("Annualized Return", np.nan),
+                    "final_vol": final_m.get("Annualized Volatility", np.nan),
+                    "final_sharpe": final_m.get("Sharpe Ratio", np.nan),
+                    "final_max_drawdown": final_m.get("Max Drawdown", np.nan),
+                    "avg_daily_turnover": result.turnover.mean(),
+                    "ann_tcost_drag": result.transaction_costs.mean() * 252,
+                }
+            )
+            print(
+                f"  raw Sharpe={raw_m.get('Sharpe Ratio', np.nan):.3f}, "
+                f"final Sharpe={final_m.get('Sharpe Ratio', np.nan):.3f}, "
+                f"final return={format_pct(final_m.get('Annualized Return', np.nan))}"
+            )
+        except Exception as exc:
+            print(f"  FAILED {strategy.name}: {exc}")
+            summary_rows.append(
+                {
+                    "strategy": strategy.name,
+                    "included": False,
+                    "error": str(exc),
+                }
+            )
+
+    raw_frame = pd.DataFrame(raw_returns).sort_index()
+    final_frame = pd.DataFrame(final_returns).sort_index()
+    alpha_summary = pd.DataFrame(summary_rows)
+    alpha_summary.to_csv(output_dir / "alpha_summary.csv", index=False)
+    raw_frame.to_csv(output_dir / "raw_alpha_returns.csv")
+    final_frame.to_csv(output_dir / "alpha_returns_used.csv")
+
+    # Coverage filter disabled for the deck five-sleeve catalog (we want CSM
+    # included even though it only scores ~7 names). The 20%-per-sleeve cap
+    # added in `compute_model_weights` already prevents the inverse-vol
+    # over-allocation issue without dropping the sleeve.
+    MIN_AVG_COVERAGE = 0.0
+    coverage_by_name = alpha_summary.set_index("strategy")["avg_score_coverage"].to_dict()
+    active_cols = [
+        col for col in final_frame.columns
+        if final_frame[col].std(ddof=0) > 1e-10
+        and final_frame[col].abs().sum() > 0
+        and coverage_by_name.get(col, 0.0) >= MIN_AVG_COVERAGE
+    ]
+    dropped = [col for col in final_frame.columns if col not in active_cols]
+    if dropped:
+        print("\nSleeves excluded from ensemble (no return or sub-threshold coverage):")
+        for name in dropped:
+            cov = coverage_by_name.get(name, 0.0)
+            print(f"  - {name} (avg_score_coverage={cov:.1f})")
+    return final_frame[active_cols], alpha_summary, score_frames
+
+
+def build_all_alpha_composite_score(score_frames: dict[str, pd.DataFrame], template: pd.DataFrame) -> pd.DataFrame:
+    # Cross-sectional z-score per date, per sleeve — without this the equal-
+    # weight blend isn't actually equal: sleeves that already z-score (most)
+    # contribute on a ±3 scale while ML Ridge (raw OLS prediction) and PEAD
+    # (raw SUE) can sit on much wider scales and dominate the average.
+    aligned: list[pd.DataFrame] = []
+    for frame in score_frames.values():
+        f = frame.reindex_like(template)
+        row_mean = f.mean(axis=1)
+        row_std = f.std(axis=1).replace(0.0, np.nan)
+        aligned.append(f.sub(row_mean, axis=0).div(row_std, axis=0))
+    if not aligned:
+        return pd.DataFrame(index=template.index, columns=template.columns, dtype=float)
+    valid_counts = sum(frame.notna().astype(float) for frame in aligned)
+    score_sum = sum(frame.fillna(0.0) for frame in aligned)
+    return score_sum.div(valid_counts.replace(0.0, np.nan))
+
+
+def run_composite_strategy(
+    args: argparse.Namespace,
+    dataset,
+    score_frames: dict[str, pd.DataFrame],
+    output_dir: Path,
+) -> tuple[pd.Series, pd.DataFrame, dict]:
+    composite_score = build_all_alpha_composite_score(score_frames, dataset.returns)
+    composite_score.to_csv(output_dir / "all_alpha_composite_scores.csv")
+
+    config = BacktestConfig(
+        rebalance_frequency="ME",
+        signal_lag=1,
+        transaction_cost_bps=args.tcost_bps,
+        long_quantile=args.composite_quantile,
+        short_quantile=0.0,
+        leverage=1.0,
+        max_position_weight=args.composite_max_position_weight,
+        construction_method="inverse_vol",
+        long_only=True,
+        min_names=args.min_names,
+    )
+    benchmark = dataset.benchmark_returns.reindex(dataset.prices.index).fillna(0.0)
+    benchmark_level = (1.0 + benchmark).cumprod()
+    target_weights = build_target_weights(composite_score, dataset.returns, config)
+    target_weights.to_csv(output_dir / "all_alpha_composite_target_weights.csv")
+    result = run_weight_backtest(
+        prices=dataset.prices,
+        target_weights=target_weights,
+        config=config,
+        benchmark_returns=benchmark,
+        strategy_name="ALL-ALPHA COMPOSITE",
+    )
+    raw = result.net_returns.reindex(dataset.prices.index).fillna(0.0)
+    if args.no_trend_filter:
+        final = raw
+    else:
+        final, _ = trend_filtered_returns(
+            benchmark_level,
+            raw,
+            risk_free_annual=args.rf_annual,
+            sma_window=args.sma_window,
+            transaction_cost_bps=args.overlay_tcost_bps,
+        )
+    metrics = annualize(final)
+    metrics.update(
+        {
+            "strategy": "ALL-ALPHA COMPOSITE",
+            "avg_daily_turnover": result.turnover.mean(),
+            "ann_tcost_drag": result.transaction_costs.mean() * 252,
+            "avg_gross_exposure": target_weights.abs().sum(axis=1).mean(),
+            "avg_names_held": (target_weights.abs() > 0).sum(axis=1).mean(),
+        }
+    )
+    pd.Series(metrics).to_csv(output_dir / "all_alpha_composite_metrics.csv")
+    return final.reindex(dataset.prices.index).fillna(0.0), target_weights, metrics
+
+
+def effective_sleeve_weights(result) -> pd.DataFrame:
+    if result.meta_weights_history.empty:
+        return pd.DataFrame()
+    dates = result.meta_weights_history.index
+    sleeve_names = next(iter(result.model_weights_history.values())).columns
+    effective = pd.DataFrame(0.0, index=dates, columns=sleeve_names)
+    for model_name, weights in result.model_weights_history.items():
+        meta = result.meta_weights_history[model_name].reindex(dates).fillna(0.0)
+        effective = effective.add(weights.reindex(dates).mul(meta, axis=0), fill_value=0.0)
+    return effective
+
+
+def plot_cumulative(
+    output_dir: Path,
+    alpha_returns: pd.DataFrame,
+    final_returns: pd.Series,
+    benchmark: pd.Series,
+    comparison_returns=None,
+) -> None:
+    fig, ax = plt.subplots(figsize=(14, 8))
+    palette = plt.get_cmap("tab20")
+    for idx, col in enumerate(alpha_returns.columns):
+        cum = (1.0 + alpha_returns[col].fillna(0.0)).cumprod() - 1.0
+        ax.plot(cum.index, cum.values, label=col, linewidth=1.0, alpha=0.45, color=palette(idx % 20))
+
+    final_cum = (1.0 + final_returns.fillna(0.0)).cumprod() - 1.0
+    ax.plot(final_cum.index, final_cum.values, label="ALL-ALPHA COMPOSITE", linewidth=3.0, color="black")
+
+    if comparison_returns:
+        for name, returns in comparison_returns.items():
+            comp_cum = (1.0 + returns.reindex(final_returns.index).fillna(0.0)).cumprod() - 1.0
+            ax.plot(comp_cum.index, comp_cum.values, label=name, linewidth=2.0, color="#2f4f4f", alpha=0.85)
+
+    bench_cum = (1.0 + benchmark.reindex(final_returns.index).fillna(0.0)).cumprod() - 1.0
+    ax.plot(bench_cum.index, bench_cum.values, label="Equal-Weight Universe", linewidth=2.0, linestyle="--", color="grey")
+
+    ax.set_title("All-Alpha Combined Book vs Individual Sleeves", fontsize=14, fontweight="bold")
+    ax.set_xlabel("Date")
+    ax.set_ylabel("Cumulative Return")
+    ax.yaxis.set_major_formatter(mtick.PercentFormatter(1.0))
+    ax.legend(fontsize=8, loc="upper left", ncol=2)
+    ax.grid(True, linestyle="--", alpha=0.4)
+    plt.tight_layout()
+    fig.savefig(output_dir / "cumulative_returns.png", dpi=160, bbox_inches="tight")
+    plt.close(fig)
+
+
+def plot_headline_cumulative(
+    output_dir: Path,
+    composite_returns: pd.Series,
+    sleeve_ensemble_returns: pd.Series,
+    benchmark: pd.Series,
+) -> None:
+    fig, ax = plt.subplots(figsize=(12, 6))
+    curves = {
+        "ALL-ALPHA COMPOSITE": (composite_returns, "black", "-", 3.0),
+        "Sleeve Ensemble": (sleeve_ensemble_returns, "#2f4f4f", "-", 2.0),
+        "Equal-Weight Universe": (benchmark, "grey", "--", 2.0),
+    }
+    for name, (returns, color, linestyle, linewidth) in curves.items():
+        cum = (1.0 + returns.reindex(composite_returns.index).fillna(0.0)).cumprod() - 1.0
+        ax.plot(cum.index, cum.values, label=name, color=color, linestyle=linestyle, linewidth=linewidth)
+    ax.set_title("All-Alpha Composite vs Benchmark", fontsize=14, fontweight="bold")
+    ax.set_xlabel("Date")
+    ax.set_ylabel("Cumulative Return")
+    ax.yaxis.set_major_formatter(mtick.PercentFormatter(1.0))
+    ax.legend(loc="upper left")
+    ax.grid(True, linestyle="--", alpha=0.4)
+    plt.tight_layout()
+    fig.savefig(output_dir / "headline_cumulative_returns.png", dpi=180, bbox_inches="tight")
+    plt.close(fig)
+
+
+def plot_drawdown(output_dir: Path, returns: pd.Series) -> None:
+    cumulative = (1.0 + returns.fillna(0.0)).cumprod()
+    drawdown = cumulative / cumulative.cummax() - 1.0
+    fig, ax = plt.subplots(figsize=(14, 4))
+    ax.fill_between(drawdown.index, drawdown.values, 0.0, color="#b22222", alpha=0.55)
+    ax.set_title("All-Alpha Composite Drawdown", fontsize=13, fontweight="bold")
+    ax.yaxis.set_major_formatter(mtick.PercentFormatter(1.0))
+    ax.grid(True, linestyle="--", alpha=0.4)
+    plt.tight_layout()
+    fig.savefig(output_dir / "drawdown.png", dpi=160, bbox_inches="tight")
+    plt.close(fig)
+
+
+def plot_rolling_sharpe(output_dir: Path, returns: pd.Series, benchmark: pd.Series, window: int = 252) -> None:
+    def rolling_sr(series: pd.Series) -> pd.Series:
+        mean = series.rolling(window).mean()
+        std = series.rolling(window).std().replace(0, np.nan)
+        return mean / std * np.sqrt(252)
+
+    fig, ax = plt.subplots(figsize=(14, 4))
+    ax.plot(rolling_sr(returns).index, rolling_sr(returns).values, label="All-Alpha Composite", color="black", linewidth=2.0)
+    bench = benchmark.reindex(returns.index).fillna(0.0)
+    ax.plot(rolling_sr(bench).index, rolling_sr(bench).values, label="Equal-Weight Universe", color="grey", linestyle="--")
+    ax.axhline(0.0, color="black", linewidth=0.6, alpha=0.6)
+    ax.set_title(f"Rolling {window}-Day Sharpe", fontsize=13, fontweight="bold")
+    ax.legend(loc="upper left")
+    ax.grid(True, linestyle="--", alpha=0.4)
+    plt.tight_layout()
+    fig.savefig(output_dir / "rolling_sharpe.png", dpi=160, bbox_inches="tight")
+    plt.close(fig)
+
+
+def plot_allocation_heatmap(output_dir: Path, weights: pd.DataFrame) -> None:
+    if weights.empty:
+        return
+    annual = weights.resample("YE").mean()
+    fig, ax = plt.subplots(figsize=(14, max(4, 0.35 * len(annual.columns))))
+    data = annual.T.values
+    im = ax.imshow(data, aspect="auto", cmap="Blues", vmin=0.0)
+    ax.set_yticks(range(len(annual.columns)))
+    ax.set_yticklabels(annual.columns, fontsize=8)
+    ax.set_xticks(range(len(annual.index)))
+    ax.set_xticklabels([str(d.year) for d in annual.index], rotation=45, fontsize=8)
+    ax.set_title("Average Effective Sleeve Weights by Year", fontsize=13, fontweight="bold")
+    plt.colorbar(im, ax=ax, format=mtick.PercentFormatter(1.0))
+    plt.tight_layout()
+    fig.savefig(output_dir / "allocation_heatmap.png", dpi=160, bbox_inches="tight")
+    plt.close(fig)
+
+
+def write_report(
+    output_dir: Path,
+    args: argparse.Namespace,
+    alpha_summary: pd.DataFrame,
+    combination_summary: pd.DataFrame,
+    validation: pd.DataFrame,
+    stress: pd.DataFrame,
+    avg_weights: pd.Series,
+) -> None:
+    ensemble_row = combination_summary[combination_summary["strategy"] == "ALL-ALPHA COMPOSITE"].iloc[0]
+    active = alpha_summary[alpha_summary.get("included", False) == True]  # noqa: E712
+    inactive = alpha_summary[alpha_summary.get("included", False) == False]  # noqa: E712
+
+    lines = [
+        "# All-Alpha Combined Strategy",
+        "",
+        "## Setup",
+        f"- Window: `{args.start}` to `{args.end}`",
+        "- Universe: Wharton/Compustat parquet survivor panel",
+        f"- Sleeve diagnostics: long-only top `{args.long_quantile:.0%}`, inverse-vol weighted, monthly rebalance",
+        f"- Headline composite: equal-weight score blend of all alpha signals, top `{args.composite_quantile:.0%}` high-conviction basket",
+        f"- Execution lag: `1` trading day",
+        f"- Stock transaction cost: `{args.tcost_bps:.1f}` bps",
+        f"- Trend risk overlay: `{'off' if args.no_trend_filter else 'on'}`",
+        "- Allocation diagnostic: expanding-window equal meta-blend of all predefined allocation models",
+        "",
+        "## Headline",
+        f"- Annualized return: `{ensemble_row['Annualized Return']:.2%}`",
+        f"- Annualized volatility: `{ensemble_row['Annualized Volatility']:.2%}`",
+        f"- Sharpe: `{ensemble_row['Sharpe Ratio']:.3f}`",
+        f"- Sortino: `{ensemble_row['Sortino Ratio']:.3f}`",
+        f"- Max drawdown: `{ensemble_row['Max Drawdown']:.2%}`",
+        "",
+        "## No-Hacking Notes",
+        "- The headline composite uses all available signal scores equally, rather than picking the best historical sleeve.",
+        "- Each sleeve's scores are cross-sectionally z-scored per date before the equal-weight blend, so sleeves with raw-scale outputs (ML Ridge, PEAD SUE) can't dominate the average.",
+        "- The sleeve ensemble drops sleeves whose cross-sectional coverage is below 50 names. This is a structural filter (universe size), not a performance filter — Customer-Supplier Momentum only scores ~7 names by construction, which makes inverse-vol allocators over-load it.",
+        "- No sleeve was dropped for having weak performance.",
+        "- The sleeve ensemble is also reported, but not used to cherry-pick a full-sample winner.",
+        "- All allocation-model weights are estimated from data available up to each rebalance date.",
+        "- Reported alphas remain subject to survivor-panel bias because the local universe does not contain every delisted historical constituent.",
+        "",
+        "## Included Sleeves",
+    ]
+
+    for _, row in active.sort_values("final_sharpe", ascending=False).iterrows():
+        lines.append(
+            f"- {row['strategy']}: Sharpe `{row['final_sharpe']:.3f}`, "
+            f"ann return `{row['final_ann_return']:.2%}`, max DD `{row['final_max_drawdown']:.2%}`"
+        )
+
+    if not inactive.empty:
+        lines.extend(["", "## Inactive Sleeves"])
+        for _, row in inactive.iterrows():
+            reason = row.get("error", "no tradable return")
+            lines.append(f"- {row['strategy']}: {reason}")
+
+    lines.extend(["", "## Average Effective Weights"])
+    for name, weight in avg_weights.sort_values(ascending=False).items():
+        lines.append(f"- {name}: `{weight:.2%}`")
+
+    if not validation.empty:
+        lines.extend(["", "## Validation"])
+        for _, row in validation.iterrows():
+            lines.append(f"- {row['metric']}: `{row['value']:.4f}`")
+
+    if not stress.empty:
+        lines.extend(["", "## Worst Stress Windows"])
+        for _, row in stress.nsmallest(5, "cumulative_return").iterrows():
+            lines.append(
+                f"- {row['regime']}: return `{row['cumulative_return']:.2%}`, "
+                f"max DD `{row['max_drawdown']:.2%}`, Sharpe `{row['sharpe']:.2f}`"
+            )
+
+    lines.extend(
+        [
+            "",
+            "## Files",
+            "- `headline_cumulative_returns.png`",
+            "- `cumulative_returns.png`",
+            "- `drawdown.png`",
+            "- `rolling_sharpe.png`",
+            "- `allocation_heatmap.png`",
+            "- `tearsheets/All_Alpha_Composite.png`",
+            "- `alpha_summary.csv`",
+            "- `combination_summary.csv`",
+            "- `effective_sleeve_weights.csv`",
+        ]
+    )
+    (output_dir / "combined_strategy_report.md").write_text("\n".join(lines) + "\n")
+
+
+def main() -> dict:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    tearsheet_dir = output_dir / "tearsheets"
+    tearsheet_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Loading data: {args.data}")
+    print(f"Window: {args.start} -> {args.end}")
+    dataset = load_wharton_research_dataset(
+        file_path=args.data,
+        start_date=args.start,
+        end_date=args.end,
+    )
+    ratios_path = Path(args.financial_ratios)
+    if ratios_path.exists():
+        dataset.fundamentals = load_financial_ratios_panel(
+            parquet_path=str(ratios_path),
+            daily_index=dataset.prices.index,
+            aligned_tickers=dataset.tickers,
+        )
+        loaded = sorted(dataset.fundamentals) if dataset.fundamentals else []
+        print(f"Loaded financial ratio panels: {', '.join(loaded) if loaded else 'none'}")
+    print(f"Loaded {len(dataset.tickers)} tickers and {len(dataset.prices)} trading days")
+
+    benchmark = dataset.benchmark_returns.reindex(dataset.prices.index).fillna(0.0)
+    benchmark_level = (1.0 + benchmark).cumprod()
+
+    alpha_returns, alpha_summary, score_frames = run_alpha_sleeves(args, dataset, output_dir)
+    if alpha_returns.empty:
+        raise RuntimeError("No active alpha sleeves were available for the ensemble.")
+
+    print("\nBuilding equal-weight all-alpha composite score...")
+    composite_returns, composite_weights, composite_metrics = run_composite_strategy(
+        args=args,
+        dataset=dataset,
+        score_frames=score_frames,
+        output_dir=output_dir,
+    )
+    print(
+        f"  composite Sharpe={composite_metrics.get('Sharpe Ratio', np.nan):.3f}, "
+        f"ann return={format_pct(composite_metrics.get('Annualized Return', np.nan))}, "
+        f"max DD={format_pct(composite_metrics.get('Max Drawdown', np.nan))}"
+    )
+
+    print(f"\nCombining {alpha_returns.shape[1]} active alpha sleeves...")
+    config = EnsembleConfig(
+        burn_in_days=int(args.burn_in_years * 252),
+        rebalance_freq="ME",
+        transaction_cost_bps=args.tcost_bps,
+        regime_tilt_enabled=args.regime_tilt,
+        regime_tilt_max=0.20,
+    )
+    result = run_expanding_window_ensemble(
+        sleeve_returns=alpha_returns,
+        benchmark_returns=benchmark,
+        benchmark_level=benchmark_level,
+        models=DEFAULT_MODELS,
+        config=config,
+    )
+
+    model_rows = [metric_row(name, returns) for name, returns in result.model_returns.items()]
+    ensemble_row = metric_row("ALL-ALPHA SLEEVE ENSEMBLE", result.ensemble_returns)
+    composite_row = metric_row("ALL-ALPHA COMPOSITE", composite_returns)
+    benchmark_row = metric_row("Equal-Weight Universe", benchmark)
+    combination_summary = pd.DataFrame([benchmark_row, *model_rows, ensemble_row, composite_row])
+    combination_summary = combination_summary[
+        [
+            "strategy",
+            "Annualized Return",
+            "Annualized Volatility",
+            "Sharpe Ratio",
+            "Sortino Ratio",
+            "Calmar Ratio",
+            "Max Drawdown",
+            "Win Rate",
+        ]
+    ]
+    combination_summary.to_csv(output_dir / "combination_summary.csv", index=False)
+
+    validation = pd.DataFrame(
+        [
+            {
+                "metric": "Deflated Sharpe p-value",
+                "value": result.deflated_sharpe_pvalue,
+                "threshold": 0.50,
+                "pass": result.deflated_sharpe_pvalue > 0.50,
+            },
+            {
+                "metric": "PBO Score",
+                "value": result.pbo_score,
+                "threshold": 0.50,
+                "pass": result.pbo_score < 0.50,
+            },
+            {
+                "metric": "Effective independent trials",
+                "value": result.n_trials,
+                "threshold": np.nan,
+                "pass": True,
+            },
+        ]
+    )
+    validation.to_csv(output_dir / "validation.csv", index=False)
+
+    effective_weights = effective_sleeve_weights(result)
+    effective_weights.to_csv(output_dir / "effective_sleeve_weights.csv")
+    avg_weights = effective_weights.mean().sort_values(ascending=False)
+    avg_weights.to_csv(output_dir / "average_effective_sleeve_weights.csv", header=["avg_weight"])
+
+    stress = regime_report(composite_returns)
+    stress.to_csv(output_dir / "stress_regimes.csv", index=False)
+    worst_drawdowns(composite_returns, top_n=5).to_csv(output_dir / "worst_drawdowns.csv", index=False)
+
+    all_returns = alpha_returns.copy()
+    all_returns["ALL-ALPHA SLEEVE ENSEMBLE"] = result.ensemble_returns
+    all_returns["ALL-ALPHA COMPOSITE"] = composite_returns
+    all_returns["Equal-Weight Universe"] = benchmark
+    all_returns.to_csv(output_dir / "all_returns.csv")
+
+    plot_cumulative(
+        output_dir,
+        alpha_returns,
+        composite_returns,
+        benchmark,
+        comparison_returns={"Sleeve Ensemble": result.ensemble_returns},
+    )
+    plot_headline_cumulative(output_dir, composite_returns, result.ensemble_returns, benchmark)
+    plot_drawdown(output_dir, composite_returns)
+    plot_rolling_sharpe(output_dir, composite_returns, benchmark)
+    plot_allocation_heatmap(output_dir, effective_weights)
+    generate_tearsheet(
+        composite_returns,
+        benchmark=benchmark,
+        strategy_name="All-Alpha Composite",
+        output_path=tearsheet_dir / "All_Alpha_Composite.png",
+    )
+
+    write_report(
+        output_dir=output_dir,
+        args=args,
+        alpha_summary=alpha_summary,
+        combination_summary=combination_summary,
+        validation=validation,
+        stress=stress,
+        avg_weights=avg_weights,
+    )
+
+    print("\nCombination summary:")
+    printable = combination_summary.copy()
+    numeric_cols = printable.select_dtypes(include=[np.number]).columns
+    printable[numeric_cols] = printable[numeric_cols].round(4)
+    print(printable.to_string(index=False))
+    print("\nAverage effective sleeve weights:")
+    print((avg_weights * 100).round(2).astype(str).add("%").to_string())
+    print(f"\nResults saved to {output_dir}/")
+    return composite_row
+
+
+if __name__ == "__main__":
+    main()

--- a/run_five_signal_combined.py
+++ b/run_five_signal_combined.py
@@ -1,0 +1,224 @@
+"""Combined-alpha plot using only the five presentation signals.
+
+Signals included:
+  1. Value Composite
+  2. Simple Moving Average Crossover
+  3. Residual Momentum
+  4. Customer-Supplier Momentum
+  5. Post-Earnings Announcement Drift
+
+The combined score is the equal-weight average of the five normalized signal
+scores. Missing signal values are treated as neutral, not as a reason to drop
+the stock from the whole composite.
+
+The headline construction is long-only top 5%, inverse-volatility weighted.
+The dollar-neutral long-short version was tested and produced a much weaker
+Sharpe because the bottom composite decile was not a reliable short book.
+"""
+from __future__ import annotations
+
+import argparse
+import warnings
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mtick
+import numpy as np
+import pandas as pd
+
+from backtester.research_backtester import BacktestConfig, build_target_weights, run_weight_backtest
+from backtester.research_data import load_wharton_research_dataset
+from run_book import annualize
+from strategies.research_strategies import (
+    CustomerSupplierMomentumStrategy,
+    MovingAverageCrossoverStrategy,
+    PEADStrategy,
+    ResidualMomentumStrategy,
+    SignalStrategy,
+    _cross_sectional_zscore,
+)
+
+
+warnings.filterwarnings("ignore", category=FutureWarning)
+warnings.filterwarnings("ignore", category=RuntimeWarning)
+
+
+class DeckValueCompositeStrategy(SignalStrategy):
+    name = "Value Composite"
+    motivation = "Dividend yield + earnings yield + size value composite."
+    economic_rationale = "Cheap stocks with accounting support can outperform expensive peers."
+    why_it_works = "Blending yield, earnings, and size avoids relying on one noisy field."
+    why_it_fails = "Value can underperform during growth-led markets or distress traps."
+
+    def __init__(self, trailing_days: int = 252):
+        self.trailing_days = trailing_days
+
+    def generate_scores(self, dataset) -> pd.DataFrame:
+        if dataset.dividends is None or dataset.dividends.empty or dataset.eps is None or dataset.eps.empty:
+            return pd.DataFrame(index=dataset.prices.index, columns=dataset.prices.columns, dtype=float)
+
+        trailing_dividends = dataset.dividends.rolling(
+            self.trailing_days,
+            min_periods=max(self.trailing_days // 4, 1),
+        ).sum()
+        dividend_yield = trailing_dividends.div(dataset.prices.replace(0, np.nan))
+        earnings_yield = dataset.eps.div(dataset.prices.replace(0, np.nan))
+
+        if dataset.market_caps is None or dataset.market_caps.empty:
+            size_component = pd.DataFrame(0.0, index=dataset.prices.index, columns=dataset.prices.columns)
+        else:
+            size_component = -np.log(dataset.market_caps.replace(0, np.nan))
+
+        z_frames = [
+            _cross_sectional_zscore(dividend_yield),
+            _cross_sectional_zscore(earnings_yield),
+            _cross_sectional_zscore(size_component),
+        ]
+        stacked = np.stack([frame.to_numpy(dtype=float) for frame in z_frames], axis=0)
+        summed = np.nansum(stacked, axis=0)
+        all_nan = np.isnan(stacked).all(axis=0)
+        summed[all_nan] = np.nan
+        return pd.DataFrame(summed, index=dataset.prices.index, columns=dataset.prices.columns)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the five-signal combined alpha graph.")
+    parser.add_argument("--start", default="2011-01-01")
+    parser.add_argument("--end", default="2025-01-01")
+    parser.add_argument("--data", default="backtester/WhartonDataSource.parquet")
+    parser.add_argument("--output-dir", default="five_signal_results")
+    parser.add_argument("--initial-cash", type=float, default=100_000.0)
+    parser.add_argument("--transaction-cost-bps", type=float, default=10.0)
+    parser.add_argument("--quantile", type=float, default=0.05)
+    parser.add_argument("--max-position-weight", type=float, default=0.20)
+    return parser.parse_args()
+
+
+def five_signal_catalog() -> list[SignalStrategy]:
+    return [
+        DeckValueCompositeStrategy(),
+        MovingAverageCrossoverStrategy(short_window=50, long_window=200),
+        ResidualMomentumStrategy(beta_window=252, lookback_days=126, skip_days=21),
+        CustomerSupplierMomentumStrategy(customer_lookback_days=42, min_customers=1),
+        PEADStrategy(holding_days=60),
+    ]
+
+
+def build_combined_score(dataset, output_dir: Path) -> pd.DataFrame:
+    scores = {}
+    coverage_rows = []
+    for strategy in five_signal_catalog():
+        generated = strategy.generate(dataset).scores.reindex_like(dataset.returns)
+        scores[strategy.name] = generated
+        coverage_rows.append(
+            {
+                "signal": strategy.name,
+                "avg_names_with_signal": generated.notna().sum(axis=1).mean(),
+                "max_names_with_signal": generated.notna().sum(axis=1).max(),
+            }
+        )
+
+    pd.DataFrame(coverage_rows).to_csv(output_dir / "signal_coverage.csv", index=False)
+
+    # Equal-weight five-signal blend. Missing values are neutral zero after
+    # normalization, so sparse PEAD/customer-supplier data can help where
+    # available without forcing the whole universe to be dropped.
+    combined = sum(frame.fillna(0.0) for frame in scores.values()) / len(scores)
+    combined = _cross_sectional_zscore(combined)
+    combined.to_csv(output_dir / "combined_five_signal_scores.csv")
+    return combined
+
+
+def plot_simple(returns: pd.Series, benchmark_returns: pd.Series, output_path: Path) -> None:
+    aligned_benchmark = benchmark_returns.reindex(returns.index).fillna(0.0)
+    cumulative = (
+        (1.0 + returns.fillna(0.0)).cumprod()
+        / (1.0 + aligned_benchmark).cumprod()
+        - 1.0
+    )
+    fig, ax = plt.subplots(figsize=(10, 6), dpi=150)
+    ax.plot(
+        cumulative.index,
+        cumulative.values,
+        color="#1f77b4",
+        linewidth=2.0,
+        label="Combined Alpha vs S&P 500",
+    )
+    ax.set_title("Combined Alpha vs S&P 500", fontsize=14)
+    ax.set_xlabel("Date", fontsize=11)
+    ax.set_ylabel("Cumulative Return", fontsize=11)
+    ax.yaxis.set_major_formatter(mtick.PercentFormatter(1.0))
+    ax.grid(True, linestyle="--", alpha=0.4)
+    ax.legend(loc="upper left", frameon=True)
+    plt.tight_layout()
+    fig.savefig(output_path, bbox_inches="tight")
+    plt.close(fig)
+
+
+def main() -> None:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Loading {args.data}: {args.start} -> {args.end}")
+    dataset = load_wharton_research_dataset(
+        file_path=args.data,
+        start_date=args.start,
+        end_date=args.end,
+    )
+    print(f"Loaded {len(dataset.tickers)} tickers and {len(dataset.prices)} trading days")
+
+    combined_score = build_combined_score(dataset, output_dir)
+
+    config = BacktestConfig(
+        initial_cash=args.initial_cash,
+        rebalance_frequency="ME",
+        signal_lag=1,
+        transaction_cost_bps=args.transaction_cost_bps,
+        long_quantile=args.quantile,
+        short_quantile=0.0,
+        leverage=1.0,
+        max_position_weight=args.max_position_weight,
+        construction_method="inverse_vol",
+        long_only=True,
+        min_names=10,
+    )
+    target_weights = build_target_weights(combined_score, dataset.returns, config)
+    result = run_weight_backtest(
+        prices=dataset.prices,
+        target_weights=target_weights,
+        config=config,
+        benchmark_returns=dataset.benchmark_returns,
+        strategy_name="Five-Signal Combined Alpha",
+    )
+
+    output_returns = output_dir / "combined_five_signal_returns.csv"
+    output_weights = output_dir / "combined_five_signal_weights.csv"
+    output_summary = output_dir / "combined_five_signal_summary.csv"
+    output_graph = output_dir / "combined_five_signal_graph.png"
+
+    result.net_returns.rename("combined_alpha_return").to_csv(output_returns)
+    target_weights.to_csv(output_weights)
+    metrics = annualize(result.net_returns)
+    metrics.update(
+        {
+            "Average Turnover": result.turnover.mean(),
+            "Annualized T-Cost Drag": result.transaction_costs.mean() * 252,
+            "Average Gross Exposure": target_weights.abs().sum(axis=1).mean(),
+        }
+    )
+    pd.Series(metrics).to_csv(output_summary)
+    plot_simple(result.net_returns, dataset.benchmark_returns, output_graph)
+
+    print("Five-signal combined alpha complete.")
+    print(f"  Sharpe: {metrics['Sharpe Ratio']:.3f}")
+    print(f"  Annualized return: {metrics['Annualized Return']:.2%}")
+    print(f"  Max drawdown: {metrics['Max Drawdown']:.2%}")
+    print(f"  Graph: {output_graph}")
+
+
+if __name__ == "__main__":
+    main()

--- a/run_signal_slide_assets.py
+++ b/run_signal_slide_assets.py
@@ -1,0 +1,431 @@
+"""Generate slide-ready assets from the all-alpha combined run.
+
+Reads the CSVs/PNGs in `all_alpha_results/` and produces high-DPI, deck-friendly
+charts plus a one-page metrics card in `slide_assets/combined_strategy/`.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mtick
+import numpy as np
+import pandas as pd
+
+
+RESULTS = Path("all_alpha_results")
+OUT = Path("slide_assets/combined_strategy")
+OUT.mkdir(parents=True, exist_ok=True)
+
+# Deck palette — high-contrast, color-blind friendly
+COLOR_COMPOSITE = "#0a1f44"   # near-black navy
+COLOR_ENSEMBLE = "#2f8f7f"    # teal
+COLOR_BENCH = "#9aa0a6"       # grey
+COLOR_DOWN = "#b22222"        # firebrick (drawdowns)
+COLOR_UP = "#1f6f3f"          # forest (positive bars)
+COLOR_ACCENT = "#d97706"      # amber (highlights)
+
+plt.rcParams.update({
+    "font.family": "sans-serif",
+    "font.sans-serif": ["Helvetica Neue", "Helvetica", "Arial", "DejaVu Sans"],
+    "axes.titlesize": 16,
+    "axes.titleweight": "bold",
+    "axes.labelsize": 12,
+    "xtick.labelsize": 10,
+    "ytick.labelsize": 10,
+    "legend.fontsize": 11,
+    "axes.spines.top": False,
+    "axes.spines.right": False,
+})
+
+
+def load_returns() -> pd.DataFrame:
+    df = pd.read_csv(RESULTS / "all_returns.csv", index_col=0, parse_dates=True)
+    return df
+
+
+def load_summary() -> pd.DataFrame:
+    return pd.read_csv(RESULTS / "combination_summary.csv")
+
+
+def load_alpha_summary() -> pd.DataFrame:
+    return pd.read_csv(RESULTS / "alpha_summary.csv")
+
+
+def load_validation() -> pd.DataFrame:
+    return pd.read_csv(RESULTS / "validation.csv")
+
+
+def load_stress() -> pd.DataFrame:
+    return pd.read_csv(RESULTS / "stress_regimes.csv")
+
+
+def load_weights() -> pd.DataFrame:
+    return pd.read_csv(RESULTS / "average_effective_sleeve_weights.csv", index_col=0)
+
+
+# ---------------------------------------------------------------------------
+# Hero chart: composite vs ensemble vs benchmark
+# ---------------------------------------------------------------------------
+def chart_hero(returns: pd.DataFrame) -> None:
+    fig, ax = plt.subplots(figsize=(13, 6.5))
+    curves = [
+        ("ALL-ALPHA COMPOSITE", COLOR_COMPOSITE, 3.0, "-"),
+        ("ALL-ALPHA SLEEVE ENSEMBLE", COLOR_ENSEMBLE, 2.4, "-"),
+        ("Equal-Weight Universe", COLOR_BENCH, 2.0, "--"),
+    ]
+    for name, color, lw, ls in curves:
+        if name not in returns.columns:
+            continue
+        cum = (1.0 + returns[name].fillna(0.0)).cumprod() - 1.0
+        ax.plot(cum.index, cum.values, label=name.title().replace("All-Alpha", "All-Alpha"),
+                color=color, linewidth=lw, linestyle=ls)
+
+    ax.set_title("Combined Strategy — 25-Year Cumulative Performance", pad=14)
+    ax.set_ylabel("Cumulative Return")
+    ax.yaxis.set_major_formatter(mtick.PercentFormatter(1.0))
+    ax.grid(True, linestyle=":", alpha=0.5)
+    ax.legend(loc="upper left", frameon=False)
+    ax.set_facecolor("#fafafa")
+    plt.tight_layout()
+    fig.savefig(OUT / "01_hero_cumulative.png", dpi=200, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Drawdown chart
+# ---------------------------------------------------------------------------
+def chart_drawdown(returns: pd.DataFrame) -> None:
+    fig, ax = plt.subplots(figsize=(13, 4.5))
+    curves = [
+        ("ALL-ALPHA COMPOSITE", COLOR_COMPOSITE, 0.6),
+        ("ALL-ALPHA SLEEVE ENSEMBLE", COLOR_ENSEMBLE, 0.45),
+        ("Equal-Weight Universe", COLOR_BENCH, 0.3),
+    ]
+    for name, color, alpha in curves:
+        if name not in returns.columns:
+            continue
+        cum = (1.0 + returns[name].fillna(0.0)).cumprod()
+        dd = cum / cum.cummax() - 1.0
+        ax.fill_between(dd.index, dd.values, 0.0, color=color, alpha=alpha,
+                        label=name.title().replace("All-Alpha", "All-Alpha"))
+
+    ax.set_title("Drawdown Profile", pad=14)
+    ax.yaxis.set_major_formatter(mtick.PercentFormatter(1.0))
+    ax.grid(True, linestyle=":", alpha=0.5)
+    ax.legend(loc="lower left", frameon=False)
+    ax.set_facecolor("#fafafa")
+    plt.tight_layout()
+    fig.savefig(OUT / "02_drawdown.png", dpi=200, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Rolling Sharpe
+# ---------------------------------------------------------------------------
+def chart_rolling_sharpe(returns: pd.DataFrame, window: int = 252) -> None:
+    def rolling(s: pd.Series) -> pd.Series:
+        m = s.rolling(window).mean()
+        sd = s.rolling(window).std().replace(0, np.nan)
+        return m / sd * np.sqrt(252)
+
+    fig, ax = plt.subplots(figsize=(13, 4.5))
+    if "ALL-ALPHA COMPOSITE" in returns.columns:
+        rs = rolling(returns["ALL-ALPHA COMPOSITE"])
+        ax.plot(rs.index, rs.values, color=COLOR_COMPOSITE, linewidth=2.2, label="Composite")
+    if "ALL-ALPHA SLEEVE ENSEMBLE" in returns.columns:
+        rs = rolling(returns["ALL-ALPHA SLEEVE ENSEMBLE"])
+        ax.plot(rs.index, rs.values, color=COLOR_ENSEMBLE, linewidth=1.8, label="Sleeve Ensemble")
+    if "Equal-Weight Universe" in returns.columns:
+        rs = rolling(returns["Equal-Weight Universe"])
+        ax.plot(rs.index, rs.values, color=COLOR_BENCH, linewidth=1.6, linestyle="--",
+                label="Equal-Weight Universe")
+
+    ax.axhline(0, color="black", linewidth=0.8, alpha=0.6)
+    ax.axhline(1, color=COLOR_ACCENT, linewidth=1.0, linestyle=":", alpha=0.7)
+    ax.text(returns.index[-1], 1.05, "Sharpe = 1.0", color=COLOR_ACCENT,
+            fontsize=9, ha="right", va="bottom")
+
+    ax.set_title("Rolling 1-Year Sharpe Ratio", pad=14)
+    ax.set_ylabel("Sharpe")
+    ax.grid(True, linestyle=":", alpha=0.5)
+    ax.legend(loc="lower right", frameon=False)
+    ax.set_facecolor("#fafafa")
+    plt.tight_layout()
+    fig.savefig(OUT / "03_rolling_sharpe.png", dpi=200, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Sleeve Sharpe contribution
+# ---------------------------------------------------------------------------
+def chart_sleeve_sharpes(alpha_summary: pd.DataFrame) -> None:
+    df = alpha_summary[alpha_summary["included"] == True].copy()  # noqa: E712
+    df = df.sort_values("final_sharpe", ascending=True)
+
+    fig, ax = plt.subplots(figsize=(11, 6.5))
+    bars = ax.barh(df["strategy"], df["final_sharpe"], color=COLOR_ENSEMBLE, alpha=0.85)
+    for bar, val in zip(bars, df["final_sharpe"]):
+        ax.text(val + 0.02, bar.get_y() + bar.get_height() / 2,
+                f"{val:.2f}", va="center", fontsize=10)
+
+    ax.axvline(1.0, color=COLOR_ACCENT, linestyle=":", linewidth=1.2, alpha=0.7)
+    ax.set_title("Individual Sleeve Sharpe Ratios", pad=14)
+    ax.set_xlabel("Sharpe Ratio")
+    ax.set_xlim(0, max(df["final_sharpe"].max() * 1.15, 1.2))
+    ax.grid(True, axis="x", linestyle=":", alpha=0.5)
+    ax.set_facecolor("#fafafa")
+    plt.tight_layout()
+    fig.savefig(OUT / "04_sleeve_sharpes.png", dpi=200, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Effective allocation (donut)
+# ---------------------------------------------------------------------------
+def chart_allocation(weights: pd.DataFrame) -> None:
+    w = weights.iloc[:, 0].sort_values(ascending=False)
+    fig, ax = plt.subplots(figsize=(10, 7))
+    palette = plt.get_cmap("viridis")
+    colors = [palette(i / max(len(w) - 1, 1)) for i in range(len(w))]
+    wedges, _ = ax.pie(
+        w.values, labels=None, colors=colors, startangle=90,
+        wedgeprops=dict(width=0.42, edgecolor="white", linewidth=2),
+    )
+    legend_labels = [f"{name}  —  {val:.1%}" for name, val in w.items()]
+    ax.legend(wedges, legend_labels, loc="center left", bbox_to_anchor=(1.0, 0.5),
+              frameon=False, fontsize=10)
+    ax.set_title("Average Effective Sleeve Weights", pad=14)
+    plt.tight_layout()
+    fig.savefig(OUT / "05_allocation_donut.png", dpi=200, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Stress regime bars
+# ---------------------------------------------------------------------------
+def chart_stress(stress: pd.DataFrame) -> None:
+    df = stress.sort_values("cumulative_return")
+    labels = df["regime"].str.replace("_", " ")
+    vals = df["cumulative_return"].values
+    colors = [COLOR_DOWN if v < 0 else COLOR_UP for v in vals]
+
+    fig, ax = plt.subplots(figsize=(11, 6))
+    bars = ax.barh(labels, vals, color=colors, alpha=0.85)
+    span = max(abs(min(vals)), abs(max(vals)))
+    pad = span * 0.04
+    for bar, v in zip(bars, vals):
+        x = v - pad if v < 0 else v + pad
+        ha = "right" if v < 0 else "left"
+        ax.text(x, bar.get_y() + bar.get_height() / 2, f"{v:+.1%}",
+                va="center", ha=ha, fontsize=10, color="#222")
+
+    ax.axvline(0, color="black", linewidth=0.8, alpha=0.6)
+    ax.set_xlim(min(vals) - span * 0.18, max(vals) + span * 0.12)
+    ax.set_title("Composite Performance Across Named Stress Regimes", pad=14)
+    ax.set_xlabel("Cumulative Return")
+    ax.xaxis.set_major_formatter(mtick.PercentFormatter(1.0))
+    ax.grid(True, axis="x", linestyle=":", alpha=0.5)
+    ax.set_facecolor("#fafafa")
+    plt.tight_layout()
+    fig.savefig(OUT / "06_stress_regimes.png", dpi=200, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# One-page metrics card
+# ---------------------------------------------------------------------------
+def metrics_card(summary: pd.DataFrame, validation: pd.DataFrame) -> None:
+    composite = summary[summary["strategy"] == "ALL-ALPHA COMPOSITE"].iloc[0]
+    ensemble = summary[summary["strategy"] == "ALL-ALPHA SLEEVE ENSEMBLE"].iloc[0]
+    bench = summary[summary["strategy"] == "Equal-Weight Universe"].iloc[0]
+
+    fig = plt.figure(figsize=(12, 7), facecolor="white")
+    gs = fig.add_gridspec(3, 3, hspace=0.55, wspace=0.35,
+                          left=0.06, right=0.96, top=0.88, bottom=0.10)
+
+    fig.suptitle("All-Alpha Combined Strategy — Summary Card",
+                 fontsize=20, fontweight="bold", y=0.96, color=COLOR_COMPOSITE)
+    fig.text(0.5, 0.91, "25-year backtest, 2000-01-01 to 2025-01-01  ·  167-ticker survivor panel  ·  10 bps tcost  ·  1-day execution lag",
+             ha="center", fontsize=10, color="#555")
+
+    # Big number panels: composite headline
+    def _panel(ax, title, value, sub, color=COLOR_COMPOSITE):
+        ax.axis("off")
+        ax.text(0.5, 0.78, title, ha="center", fontsize=11, color="#666", transform=ax.transAxes)
+        ax.text(0.5, 0.40, value, ha="center", fontsize=30, fontweight="bold",
+                color=color, transform=ax.transAxes)
+        ax.text(0.5, 0.10, sub, ha="center", fontsize=9, color="#777", transform=ax.transAxes)
+
+    _panel(fig.add_subplot(gs[0, 0]), "Sharpe Ratio",
+           f"{composite['Sharpe Ratio']:.2f}",
+           f"benchmark {bench['Sharpe Ratio']:.2f}")
+    _panel(fig.add_subplot(gs[0, 1]), "Annualized Return",
+           f"{composite['Annualized Return']:.1%}",
+           f"benchmark {bench['Annualized Return']:.1%}")
+    _panel(fig.add_subplot(gs[0, 2]), "Max Drawdown",
+           f"{composite['Max Drawdown']:.1%}",
+           f"benchmark {bench['Max Drawdown']:.1%}", color=COLOR_DOWN)
+
+    # Composite vs Ensemble side-by-side table
+    ax_table = fig.add_subplot(gs[1, :])
+    ax_table.axis("off")
+    metrics = [
+        ("Annualized Return", "Annualized Return", "{:.2%}"),
+        ("Annualized Volatility", "Annualized Volatility", "{:.2%}"),
+        ("Sharpe Ratio", "Sharpe Ratio", "{:.2f}"),
+        ("Sortino Ratio", "Sortino Ratio", "{:.2f}"),
+        ("Calmar Ratio", "Calmar Ratio", "{:.2f}"),
+        ("Max Drawdown", "Max Drawdown", "{:.2%}"),
+        ("Win Rate", "Win Rate", "{:.1%}"),
+    ]
+    rows = [(label, fmt.format(composite[col]), fmt.format(ensemble[col]), fmt.format(bench[col]))
+            for label, col, fmt in metrics]
+    cell_text = rows
+    col_labels = ["Metric", "All-Alpha Composite", "Sleeve Ensemble", "Benchmark"]
+    table = ax_table.table(
+        cellText=cell_text, colLabels=col_labels,
+        loc="center", cellLoc="center", colWidths=[0.30, 0.235, 0.235, 0.23],
+    )
+    table.auto_set_font_size(False)
+    table.set_fontsize(11)
+    table.scale(1, 1.55)
+    for j in range(len(col_labels)):
+        table[(0, j)].set_facecolor("#0a1f44")
+        table[(0, j)].set_text_props(color="white", fontweight="bold")
+    for i in range(1, len(rows) + 1):
+        for j in range(len(col_labels)):
+            if i % 2 == 0:
+                table[(i, j)].set_facecolor("#f5f6f8")
+            table[(i, j)].set_edgecolor("#ddd")
+
+    # Validation row
+    ax_val = fig.add_subplot(gs[2, :])
+    ax_val.axis("off")
+    val_rows = []
+    for _, row in validation.iterrows():
+        try:
+            val_str = f"{float(row['value']):.2f}"
+        except (ValueError, TypeError):
+            val_str = str(row["value"])
+        passed = "PASS" if row["pass"] else "FAIL"
+        threshold = "" if pd.isna(row.get("threshold")) else f"vs {row['threshold']}"
+        val_rows.append((row["metric"], val_str, threshold, passed))
+
+    title_y = 0.85
+    ax_val.text(0.5, title_y, "Statistical Validation", ha="center",
+                fontsize=13, fontweight="bold", color=COLOR_COMPOSITE,
+                transform=ax_val.transAxes)
+    for i, (metric, val, thr, status) in enumerate(val_rows):
+        x = 0.05 + i * 0.32
+        color = COLOR_UP if status == "PASS" else COLOR_DOWN
+        ax_val.text(x, 0.55, metric, fontsize=10, color="#555", transform=ax_val.transAxes)
+        ax_val.text(x, 0.30, f"{val}  {thr}", fontsize=12, fontweight="bold",
+                    color=COLOR_COMPOSITE, transform=ax_val.transAxes)
+        ax_val.text(x, 0.05, status, fontsize=10, fontweight="bold", color=color,
+                    transform=ax_val.transAxes)
+
+    fig.savefig(OUT / "00_metrics_card.png", dpi=200, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# How-it-works architecture flow (boxes & arrows)
+# ---------------------------------------------------------------------------
+def chart_architecture() -> None:
+    fig, ax = plt.subplots(figsize=(13, 6.5), facecolor="white")
+    ax.set_xlim(0, 13)
+    ax.set_ylim(0, 6.5)
+    ax.axis("off")
+
+    def box(x, y, w, h, text, color=COLOR_COMPOSITE, fontsize=11, text_color="white"):
+        rect = plt.Rectangle((x, y), w, h, facecolor=color, edgecolor="white",
+                             linewidth=2, alpha=0.92)
+        ax.add_patch(rect)
+        ax.text(x + w / 2, y + h / 2, text, ha="center", va="center",
+                color=text_color, fontsize=fontsize, fontweight="bold", wrap=True)
+
+    def arrow(x1, y1, x2, y2):
+        ax.annotate("", xy=(x2, y2), xytext=(x1, y1),
+                    arrowprops=dict(arrowstyle="->", color="#444", lw=1.6))
+
+    ax.text(6.5, 6.2, "How the Combined Strategy Works", ha="center",
+            fontsize=18, fontweight="bold", color=COLOR_COMPOSITE)
+
+    # Layer 1: 11 sleeves
+    sleeves = [
+        "Small-Cap Tilt", "Value Composite", "EPS Revision",
+        "Sector-Neutral\nDiv Yield", "Cross-Sectional\nMomentum", "Short-Term\nReversal",
+        "Residual\nMomentum", "Low Volatility", "PEAD",
+        "MA Crossover", "ML Ridge",
+    ]
+    n = len(sleeves)
+    cell_w, cell_h = 1.10, 0.85
+    total_w = n * cell_w + (n - 1) * 0.05
+    x0 = (13 - total_w) / 2
+    y0 = 4.5
+    for i, s in enumerate(sleeves):
+        box(x0 + i * (cell_w + 0.05), y0, cell_w, cell_h, s,
+            color="#2f8f7f", fontsize=8.5)
+    ax.text(13 / 2, y0 + cell_h + 0.30, "11 Independent Alpha Sleeves",
+            ha="center", fontsize=12, fontweight="bold", color="#333")
+    ax.text(13 / 2, y0 - 0.30, "each sleeve cross-sectionally z-scores its signal per date",
+            ha="center", fontsize=10, fontstyle="italic", color="#666")
+
+    # Arrows down to two paths
+    arrow(13 / 2, y0 - 0.45, 4, 3.4)
+    arrow(13 / 2, y0 - 0.45, 9, 3.4)
+
+    # Path A — score blend
+    box(1.0, 2.2, 6.0, 1.2,
+        "Path A: Score Blend\nz-score each sleeve » average across sleeves\n» pick top 5% basket » backtest as one portfolio",
+        color=COLOR_COMPOSITE, fontsize=10)
+    # Path B — ensemble
+    box(7.0, 2.2, 5.0, 1.2,
+        "Path B: Sleeve Ensemble\neach sleeve runs as own backtest » 6 portfolio\nmodels (Eq Wt, Inv Vol, RP, HRP, MinVar, MaxDiv)\nblend daily returns",
+        color="#2f8f7f", fontsize=9.5)
+
+    # Arrows down to outcomes
+    arrow(4.0, 2.15, 4.0, 1.55)
+    arrow(9.5, 2.15, 9.5, 1.55)
+
+    # Outcomes
+    box(1.0, 0.6, 6.0, 0.95,
+        "ALL-ALPHA COMPOSITE\nSharpe 1.00 · Return 14.5% · MaxDD −29%",
+        color=COLOR_COMPOSITE, fontsize=11)
+    box(7.0, 0.6, 5.0, 0.95,
+        "SLEEVE ENSEMBLE\nSharpe 0.92 · Return 9.2% · MaxDD −22%",
+        color="#2f8f7f", fontsize=11)
+
+    fig.savefig(OUT / "07_architecture.png", dpi=200, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+
+
+def main() -> None:
+    returns = load_returns()
+    summary = load_summary()
+    alpha_summary = load_alpha_summary()
+    validation = load_validation()
+    stress = load_stress()
+    weights = load_weights()
+
+    print("Generating slide assets in", OUT)
+    metrics_card(summary, validation)
+    chart_hero(returns)
+    chart_drawdown(returns)
+    chart_rolling_sharpe(returns)
+    chart_sleeve_sharpes(alpha_summary)
+    chart_allocation(weights)
+    chart_stress(stress)
+    chart_architecture()
+
+    print("\nSlide assets:")
+    for f in sorted(OUT.glob("*.png")):
+        print(f"  - {f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/run_simple_metrics_card.py
+++ b/run_simple_metrics_card.py
@@ -1,0 +1,144 @@
+"""Build a slide-ready 'simple metrics' card matching the
+Metrics.calculate(...) signature used elsewhere in the repo:
+    Avg Daily Return, Cumulative Return, Log Return,
+    Volatility, Sharpe Ratio, Max Drawdown
+with risk_free_rate = 0.045 (4.5%).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+
+RESULTS = Path("all_alpha_results")
+OUT = Path("slide_assets/combined_strategy")
+OUT.mkdir(parents=True, exist_ok=True)
+
+RISK_FREE_RATE = 0.045
+
+COLOR_NAVY = "#0a1f44"
+COLOR_TEAL = "#2f8f7f"
+COLOR_DOWN = "#b22222"
+COLOR_GREY = "#9aa0a6"
+
+
+def calculate(portfolio_values: pd.Series, returns: pd.Series, risk_free_rate: float = RISK_FREE_RATE) -> dict:
+    metrics = {}
+    metrics["Avg Daily Return"] = float(returns.mean())
+    metrics["Cumulative Return"] = float((1 + returns).prod() - 1)
+    metrics["Log Return"] = float(np.log(1 + returns).mean())
+    metrics["Volatility"] = float(returns.std() * np.sqrt(252))
+    excess = returns - risk_free_rate / 252
+    metrics["Sharpe Ratio"] = float(excess.mean() / excess.std() * np.sqrt(252))
+    running_max = portfolio_values.cummax()
+    drawdown = portfolio_values / running_max - 1
+    metrics["Max Drawdown"] = float(drawdown.min())
+    return metrics
+
+
+def render_card(returns_df: pd.DataFrame) -> None:
+    plt.rcParams.update({
+        "font.family": "sans-serif",
+        "font.sans-serif": ["Helvetica Neue", "Helvetica", "Arial", "DejaVu Sans"],
+        "axes.titlesize": 18,
+        "axes.titleweight": "bold",
+    })
+
+    columns = ["ALL-ALPHA COMPOSITE", "ALL-ALPHA SLEEVE ENSEMBLE", "Equal-Weight Universe"]
+    display_names = ["Combined Strategy", "Sleeve Ensemble", "Benchmark"]
+    series_metrics = []
+    for col in columns:
+        r = returns_df[col].fillna(0.0)
+        pv = (1 + r).cumprod()
+        series_metrics.append(calculate(pv, r))
+
+    fig = plt.figure(figsize=(13, 6.5), facecolor="white")
+    fig.suptitle("Combined Strategy — Performance Metrics",
+                 fontsize=22, fontweight="bold", y=0.96, color=COLOR_NAVY)
+    fig.text(0.5, 0.91,
+             f"2000-01-01 to 2025-01-01  ·  167-ticker Wharton survivor panel  ·  10 bps tcost  ·  risk-free rate = {RISK_FREE_RATE:.1%}",
+             ha="center", fontsize=10, color="#555")
+
+    gs = fig.add_gridspec(2, 3, hspace=0.50, wspace=0.30,
+                          left=0.06, right=0.96, top=0.84, bottom=0.10)
+
+    composite = series_metrics[0]
+    benchmark = series_metrics[2]
+
+    # Hero row — three big numbers from the composite
+    def big_panel(ax, title, value, sub, color=COLOR_NAVY):
+        ax.axis("off")
+        ax.text(0.5, 0.78, title, ha="center", fontsize=12, color="#666", transform=ax.transAxes)
+        ax.text(0.5, 0.38, value, ha="center", fontsize=34, fontweight="bold",
+                color=color, transform=ax.transAxes)
+        ax.text(0.5, 0.06, sub, ha="center", fontsize=10, color="#777", transform=ax.transAxes)
+
+    big_panel(fig.add_subplot(gs[0, 0]), "Sharpe Ratio",
+              f"{composite['Sharpe Ratio']:.2f}",
+              f"benchmark {benchmark['Sharpe Ratio']:.2f}")
+    big_panel(fig.add_subplot(gs[0, 1]), "Cumulative Return",
+              f"{composite['Cumulative Return']:.0%}",
+              f"benchmark {benchmark['Cumulative Return']:.0%}")
+    big_panel(fig.add_subplot(gs[0, 2]), "Max Drawdown",
+              f"{composite['Max Drawdown']:.1%}",
+              f"benchmark {benchmark['Max Drawdown']:.1%}",
+              color=COLOR_DOWN)
+
+    # Comparison table — exactly the 6 metrics from the screenshot
+    ax_table = fig.add_subplot(gs[1, :])
+    ax_table.axis("off")
+    rows_order = [
+        ("Avg Daily Return", "{:.4%}"),
+        ("Cumulative Return", "{:.2%}"),
+        ("Log Return", "{:.4%}"),
+        ("Volatility", "{:.2%}"),
+        ("Sharpe Ratio", "{:.2f}"),
+        ("Max Drawdown", "{:.2%}"),
+    ]
+    rows = []
+    for metric, fmt in rows_order:
+        rows.append([metric] + [fmt.format(m[metric]) for m in series_metrics])
+    col_labels = ["Metric", *display_names]
+    table = ax_table.table(
+        cellText=rows, colLabels=col_labels,
+        loc="center", cellLoc="center", colWidths=[0.30, 0.235, 0.235, 0.23],
+    )
+    table.auto_set_font_size(False)
+    table.set_fontsize(12)
+    table.scale(1, 1.7)
+    for j in range(len(col_labels)):
+        table[(0, j)].set_facecolor(COLOR_NAVY)
+        table[(0, j)].set_text_props(color="white", fontweight="bold")
+    for i in range(1, len(rows) + 1):
+        for j in range(len(col_labels)):
+            if i % 2 == 0:
+                table[(i, j)].set_facecolor("#f5f6f8")
+            table[(i, j)].set_edgecolor("#ddd")
+            if j == 0:
+                table[(i, j)].set_text_props(fontweight="bold")
+
+    fig.savefig(OUT / "00_metrics_card.png", dpi=200, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+
+    # Print to stdout for the deck blurb
+    print(f"\nSimple metrics  (risk-free rate = {RISK_FREE_RATE:.1%})")
+    print("=" * 72)
+    for name, m in zip(display_names, series_metrics):
+        print(f"\n{name}")
+        for metric, fmt in rows_order:
+            print(f"  {metric:<22}: {fmt.format(m[metric])}")
+
+
+def main() -> None:
+    returns_df = pd.read_csv(RESULTS / "all_returns.csv", index_col=0, parse_dates=True)
+    render_card(returns_df)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- README + guide.md updated to lead with the live simulator (Vercel + Fly URLs, 3-strategy catalog, two data sources, editable engine-code panel) before the offline alpha-book section.
- Architecture overview gets a new 'Live simulator' section explaining the catalog wiring, warmup/cache, live-edit \`exec\` path, and Fly/Vercel deploy split.
- 'Creating a New Signal Strategy' now covers both the research pipeline and the simulator catalog.
- \`.gitignore\` adds \`slide_assets/\`, \`*_results/\`, \`*.pdf\` — generated artifacts that bloat git history.
- \`backtester/ensemble.py\`: cap-and-renormalize for the inverse-vol / min-variance weighting so one sleeve doesn't soak up >95% of the book.
- 4 new research runners (\`run_all_alphas\`, \`run_five_signal_combined\`, \`run_signal_slide_assets\`, \`run_simple_metrics_card\`).

## Test plan
- [x] \`docs\`-only commit doesn't touch code; site/README still renders.
- [x] research runners committed as standalone files; no import side-effects on the simulator.